### PR TITLE
Move classifier to a subprocess and make model name required

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,28 +398,30 @@ For detail on what is logged including format see the source code for the [chann
 ## Auto Priority
 With the `-P` option, channels that meet specific conditions will automatically be added to the priority list.  Currently, only one algorithm is supported: Voice priority.  With this, those channels that have more voice transmissions than data/skip transmissions will be added to the priority list.
 
-If the number of voice transmissions is less than the number of data/skip transmissions, then the priority flag be reoved for that frequency.  This will override and priorities assigned in the [priority file](#priority-handling).
+If the number of voice transmissions is less than the number of data/skip transmissions, then the priority flag will be removed for that frequency.  This will override any priorities assigned in the [priority file](#priority-handling).
 
-Auto priority currently requires audio classification so `--voice` will automatically be enabled if this option is selected.
+Auto priority currently requires audio classification so `--voice` will automatically be enabled if this option is selected.  Therefore, `--model` must also be specified when using auto priority.
 
 ## Logging
-Application logging events are written to `ham2mon.log`.  These are seperate from channel logging events (-L option) and are intended for application debugging.
+Application logging events are written to `ham2mon.log`.  These are separate from channel logging events (-L option) and are intended for application debugging.
 
 ## Audio Classification
 *Note: The classification is not 100% accurate.  There will be both false positives and negatives.*
 
-Recorded audio can be classified using a pre-trained model.  The model must be present and the tensorflow python module must be installed.  The model file can be specified with the `--model` and option.
+Recorded audio can be classified using a pre-trained model.  The model is an optional artifact not included in the repository when cloned (see releases).  You must separately download it and add it to your system. The optional tensorflow python module must also be installed (see installation instructions).
 
-The command line options (--voice, --data, and --skip) must be specified to indicate what recordings are saved.  All others will be discarded.  The classification feature does not impact what is heard over the speaker.  If no options are provided then classification is disabled (this is the default).  If any of the options are provided then record mode ("-w") will be automatically enabled.
+The model file must be specified using the `--model <path>` option.
 
-The classification designator will be added after the frequency (e.g. 460.125_V_1698933610.wav for voice).  Only 16bps audio is currently supported so enable it with "-b 16".
+At least one of the command line options (`--voice`, `--data`, and `--skip`) must be specified to indicate what recordings are saved.  All others will be discarded.  The classification feature does not impact what is heard over the speaker.  If no options are provided then classification is disabled (this is the default).  If any of the options are provided then record mode (`-w`) will be automatically enabled.
 
-No capability is provided to train the model.  Training data will not be provided.  Those interested in training their own model can review [xmits_train](https://gitlab.com/john---/xmits_train) for what was done to train the provided model.
+The classification designator will be added after the frequency (e.g. 460.125_V_1698933610.wav for voice).  Only 16-bit audio is currently supported so enable it with `-b 16`.
+
+No capability is provided to train the model.  Training data will not be provided.  Those interested in training their own model can review [xmits_train](https://gitlab.com/john---/xmits_train) for what was done to train the available model.
 
 ## Ham2mon Development
 
 ### End-to-End Testing
-To validate changes to ham2mon source code that may impact scanning it is best to "replay" a raw IQ file into ham2mon to confirm things are working as expected.  This can be done by first recording an IQ file(s) and then replaying it im ham2mon.
+To validate changes to ham2mon source code that may impact scanning it is best to "replay" a raw IQ file into ham2mon to confirm things are working as expected.  This can be done by first recording an IQ file(s) and then replaying it in ham2mon.
 
 Example recording with airspy:
 

--- a/apps/classification.py
+++ b/apps/classification.py
@@ -3,22 +3,19 @@
 """
 Created on Wed Nov 11 2023
 
-Code is copied from:
-    https://gitlab.com/john---/xmit_processor
-
 @author: john
 """
 
-from pathlib import Path
-import numpy as np
+import os
+import sys
 import logging
-from typing import Dict, Literal, Any, Optional
-
+import subprocess
+import select
+import threading
+import time
+from pathlib import Path
+from typing import Dict, Literal, Optional
 from dataclasses import dataclass
-
-
-# stops log spamming for a harmless debug message
-logging.getLogger("h5py").setLevel(logging.INFO)
 
 @dataclass(kw_only=True)
 class ClassifierParams:
@@ -31,121 +28,188 @@ class ClassifierParams:
 class ClassificationNotWanted(Exception):
     pass
 
-def _load_tensorflow():
-    try:
-        import tensorflow as tf  # pyright: ignore[reportMissingImports, reportMissingModuleSource]
-        return tf
-    except ImportError as error:
-        raise ImportError(f'tensorflow module did not load ({error})') from error
-
 class Classifier(object):
 
     def __init__(self, params: ClassifierParams, audio_rate: int):
-
         self.params = params
         self.audio_rate = audio_rate
+        self._proc: Optional[subprocess.Popen[str]] = None
+        self._loaded = False
 
         if all(value is False for value in self.params.wanted.values()):
             raise ClassificationNotWanted()
 
-        self.tf = _load_tensorflow()
+        # Resolve model path
+        if self.params.model_file_name is None:
+            raise FileNotFoundError("Model file not specified.")
 
-        path = Path(f'{self.params.model_file_name}')
+        self.model_path = Path(self.params.model_file_name)
+        if not self.model_path.exists():
+            raise FileNotFoundError(f"Model file does not exist: {self.model_path}")
+        self.model_path = self.model_path.resolve(strict=True)
 
-        path.resolve(strict=True)
-        self.load_model(path)
-        logging.info(f'Model loaded: {path.resolve()}')
+        # Eagerly start the subprocess and load TensorFlow at construction time
+        # to ensure classification is ready before transmissions begin.
+        self._ensure_loaded()
 
-    def load_model(self, path: Path) -> None:
-        tf = self.tf
-        self.model = tf.lite.Interpreter(model_path=path.absolute().as_posix())
-        self.model.allocate_tensors()
-        self.input_details = self.model.get_input_details()
-        self.output_details = self.model.get_output_details()
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+
+        # Start classification service as a subprocess
+        script_dir = Path(__file__).parent
+        service_script = script_dir / "classification_service.py"
+
+        logging.info("Starting background TensorFlow classification service subprocess...")
+
+        # bufsize=1 ensures line-buffering so that readline and write lines flush immediately.
+        self._proc = subprocess.Popen(
+            [sys.executable, service_script.as_posix(),
+             "--model", self.model_path.absolute().as_posix(),
+             "--audio_rate", str(self.audio_rate)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1
+        )
+
+        # Read the ready signal to ensure the subprocess initialized correctly
+        if self._proc is None or self._proc.stdout is None or self._proc.stderr is None:
+            raise RuntimeError("Classification service failed to initialize.")
+
+        ready = ""
+        # Check if stdout has data to avoid blocking if the service crashed instantly.
+        # We wait up to 120 seconds for the service to start, checking in intervals
+        # to see if the process exited early.
+        timeout = 120.0
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            r, _, _ = select.select([self._proc.stdout], [], [], 0.5)
+            if r:
+                ready = self._proc.stdout.readline().strip()
+                break
+            # Check if the process exited early
+            if self._proc.poll() is not None:
+                break
+
+        if ready != "READY":
+            # Retrieve available startup error traceback details from stderr
+            err_msg = ""
+            try:
+                er, _, _ = select.select([self._proc.stderr], [], [], 5.0)
+                if er:
+                    fd = self._proc.stderr.fileno()
+                    # Set non-blocking so read() returns immediately if select() was a spurious wakeup.
+                    # Note: this leaves the fd non-blocking, which is safe since the subprocess
+                    # is about to be cleaned up/terminated due to startup failure.
+                    os.set_blocking(fd, False)
+                    try:
+                        err_bytes = os.read(fd, 4096)
+                        err_msg = err_bytes.decode('utf-8', errors='replace')
+                    except BlockingIOError:
+                        pass
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"Classification service failed to initialize.\n"
+                f"Handshake status: {ready!r}\n"
+                f"Subprocess stderr:\n{err_msg}"
+            )
+
+        # Start a daemon background thread to consume service's stderr
+        # and forward messages to the logs, avoiding pipe-buffer block deadlocks.
+        def log_stderr_stream(pipe):
+            try:
+                for line in pipe:
+                    stripped = line.strip()
+                    if stripped:
+                        logging.warning(f"TensorFlow Service: {stripped}")
+            except Exception as e:
+                try:
+                    logging.debug(f"TensorFlow Service stderr drain thread exception: {e}")
+                except Exception:
+                    pass
+            finally:
+                try:
+                    logging.debug("TensorFlow Service stderr drain thread exiting.")
+                except Exception:
+                    pass
+
+        t = threading.Thread(target=log_stderr_stream, args=(self._proc.stderr,), daemon=True)
+        t.start()
+
+        logging.info("TensorFlow classification service started successfully!")
+        self._loaded = True
 
     def is_wanted(self, file: str) -> tuple[bool, Optional[Literal['V', 'D', 'S']]]:
+        # Self-healing: restart the service if it crashed or is not running
+        if (self._proc is None
+                or self._proc.poll() is not None
+                or self._proc.stdin is None
+                or self._proc.stdout is None):
+            logging.warning("TensorFlow classification service is not running. Attempting restart...")
+            self.clean_up()
+            try:
+                self._ensure_loaded()
+            except Exception as e:
+                logging.error(f"Failed to restart TensorFlow classification service: {e}")
+                return False, None
 
-        spectrogram = self.get_spectrogram(file)
-        detected_as = self.predict(spectrogram)
+        if (self._proc is None
+                or self._proc.poll() is not None
+                or self._proc.stdin is None
+                or self._proc.stdout is None):
+            return False, None
 
+        # Write filename to process stdin
+        self._proc.stdin.write(file + "\n")
+        self._proc.stdin.flush()
+
+        # Read prediction response from process stdout with a timeout to avoid hangs
+        ready_r, _, _ = select.select([self._proc.stdout], [], [], 5.0)
+        if not ready_r:
+            logging.error(f"Timeout waiting for classification response for file: {file}")
+            logging.warning(f"Classification result lost for {file} due to subprocess hang.")
+            self.clean_up()  # Terminate hung subprocess
+            return False, None
+
+        line = self._proc.stdout.readline().strip()
+        if not line:
+            return False, None
+
+        detected_as = line if line in ('V', 'D', 'S') else None
         wanted = bool(detected_as and self.params.wanted[detected_as])
         return wanted, detected_as
 
-    # convert the waveform into a spectrogram
-    def get_spectrogram(self, file: str) -> Any:
-        tf = self.tf
-        audio_binary = tf.io.read_file(file)
+    def clean_up(self) -> None:
+        if not self._proc:
+            return
+
         try:
-            waveform = self.decode_audio(audio_binary)
-        except Exception as error:
-            logging.error(f'could not decode audio (try "-b 16" option or disable classification): {error}')
-            raise
+            if self._proc.stdin:
+                self._proc.stdin.close()
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logging.warning("Classification service did not terminate in time. Killing it...")
+                self._proc.kill()
+                self._proc.wait()
+        except Exception as e:
+            logging.debug(f"Error during classification service cleanup: {e}")
+        finally:
+            self._proc = None
+            self._loaded = False
 
-        total_samples: int = tf.size(waveform).numpy()
-        sample_rate = self.audio_rate
-        #length = round(total_samples/sample_rate, 3)
+    def __enter__(self):
+        return self
 
-        clip_length = 2  # value may ve because model was trained with min. 2 sec clips
-        target_samples = sample_rate * clip_length
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.clean_up()
 
-        # Shorten to target length
-        # TODO:  add this to preprocess for training and get rid of pre-shortening
-        #        when creating training data
-        #logging.debug('current elements: %d', tf.size(waveform).numpy())
-        middle = total_samples/2
-        start = int(middle - target_samples/2)
-        if start < 0:
-            start = 0
-        end = int(middle + target_samples/2)
-        waveform = waveform[start:end]
-        #logging.debug('length: %d [ start: %d middle: %d end: %d]', tf.size(waveform).numpy(), start, middle, end)
-
-        # Padding for files with less than 16000 samples (2 seconds of 8 Khz sample rate)
-        zero_padding = tf.zeros([target_samples] - tf.shape(waveform), dtype=tf.float32)
-
-        # Concatenate audio with padding so that all audio clips will be of the
-        # same length
-        waveform = tf.cast(waveform, tf.float32)
-        equal_length = tf.concat([waveform, zero_padding], 0)
-        spectrogram = tf.signal.stft(
-            equal_length, frame_length=255, frame_step=128)
-
-        spectrogram = tf.abs(spectrogram)
-
-        spectro = []
-        spectro.append(spectrogram.numpy())
-        # logging.debug(f'{spectro =}')
-        spectro = np.expand_dims(spectro, axis=-1) # TODO:  what is this dimension for?
-        # logging.debug(f' after: {spectro =}')
-
-        return spectro
-
-    def decode_audio(self, audio_binary: Any) -> Any:
-        tf = self.tf
-        audio, _ = tf.audio.decode_wav(audio_binary)
-        return tf.squeeze(audio, axis=-1)
-
-    def predict(self, spectrogram: Any) -> Optional[Literal['V', 'D', 'S']]:
-        if spectrogram is None:
-            return None
-
-        # prediction = model(spectrogram) # full TF
-
-        input_data = spectrogram
-        self.model.set_tensor(self.input_details[0]['index'], input_data)
-
-        self.model.invoke()
-
-        prediction = self.model.get_tensor(self.output_details[0]['index'])
-
-        types: tuple[Literal['V', 'D', 'S'], ...] = ('V', 'D', 'S')
-
-        # this will extract probsbilties for each of the labels
-        # predictions = {}
-        # for index, a_pred in np.ndenumerate(prediction[0]):
-        #     predictions[types[index[0]]] = round(float(a_pred), 3)
-
-        return types[np.argmax(prediction[0])]
+    def __del__(self):
+        self.clean_up()
 
 def main():
     """Test the classifier
@@ -155,12 +219,13 @@ def main():
     """
 
     audio_rate = 8000
+    model_file_name = Path(__file__).parent / 'model' / 'model_1.tflite'
     classifier_params = ClassifierParams(
         wanted={'V': True,
                 'D': True,
                 'S': True
         },
-        model_file_name=Path('model/model_1.tflite')
+        model_file_name=model_file_name
     )
 
     try:
@@ -171,6 +236,7 @@ def main():
     print(f'should be voice (V) got {classifier.is_wanted("test/voice.wav")[1]}')
     print(f'should be data (D) got {classifier.is_wanted("test/data.wav")[1]}')
     print(f'should be skip (S) got {classifier.is_wanted("test/skip.wav")[1]}')
+    classifier.clean_up()
 
 if __name__ == '__main__':
     try:

--- a/apps/classification_service.py
+++ b/apps/classification_service.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+TensorFlow Classification Service.
+Runs as a separate subprocess to isolate TensorFlow's signal handlers and threads.
+"""
+
+import sys
+import argparse
+from pathlib import Path
+import numpy as np
+
+try:
+    import tensorflow as tf
+except ImportError as error:
+    print(f"tensorflow module did not load ({error})", file=sys.stderr)
+    sys.exit(1)
+
+class ServiceClassifier:
+    def __init__(self, model_path: Path, audio_rate: int):
+        self.audio_rate = audio_rate
+        self.model = tf.lite.Interpreter(model_path=model_path.absolute().as_posix())
+        self.model.allocate_tensors()
+        self.input_details = self.model.get_input_details()
+        self.output_details = self.model.get_output_details()
+
+    def decode_audio(self, audio_binary):
+        audio, _ = tf.audio.decode_wav(audio_binary)
+        return tf.squeeze(audio, axis=-1)
+
+    def get_spectrogram(self, file_path: str):
+        audio_binary = tf.io.read_file(file_path)
+        waveform = self.decode_audio(audio_binary)
+        total_samples = tf.size(waveform).numpy()
+
+        target_samples = self.audio_rate * 2  # 2 second clip
+        middle = total_samples / 2
+        start = int(middle - target_samples / 2)
+        if start < 0:
+            start = 0
+        end = int(middle + target_samples / 2)
+        waveform = waveform[start:end]
+
+        zero_padding = tf.zeros([target_samples] - tf.shape(waveform), dtype=tf.float32)
+        waveform = tf.cast(waveform, tf.float32)
+        equal_length = tf.concat([waveform, zero_padding], 0)
+
+        spectrogram = tf.signal.stft(equal_length, frame_length=255, frame_step=128)
+        spectrogram = tf.abs(spectrogram)
+
+        spectro = [spectrogram.numpy()]
+        spectro = np.expand_dims(spectro, axis=-1)
+        return spectro
+
+    def predict(self, spectrogram):
+        if spectrogram is None:
+            return None
+        self.model.set_tensor(self.input_details[0]['index'], spectrogram)
+        self.model.invoke()
+        prediction = self.model.get_tensor(self.output_details[0]['index'])
+        types = ('V', 'D', 'S')
+        return types[np.argmax(prediction[0])]
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, required=True, help="Path to model")
+    parser.add_argument("--audio_rate", type=int, required=True, help="Audio sample rate")
+    args = parser.parse_args()
+
+    try:
+        classifier = ServiceClassifier(Path(args.model), args.audio_rate)
+    except Exception as e:
+        print(f"Could not initialize ServiceClassifier: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Ready signal to parent process
+    sys.stdout.write("READY\n")
+    sys.stdout.flush()
+
+    # Simple command loop: read filename, output classification
+    while True:
+        try:
+            line = sys.stdin.readline()
+            if not line:
+                break
+            file_path = line.strip()
+            if not file_path:
+                continue
+
+            try:
+                spectrogram = classifier.get_spectrogram(file_path)
+                result = classifier.predict(spectrogram)
+            except Exception as pe:
+                print(f"Prediction error for file '{file_path}': {pe}", file=sys.stderr)
+                sys.stderr.flush()
+                result = "S" # default fallback to Skip if prediction fails
+
+            sys.stdout.write(f"{result}\n")
+            sys.stdout.flush()
+        except KeyboardInterrupt:
+            break
+        except Exception:
+            break
+
+if __name__ == "__main__":
+    main()

--- a/apps/h2m_parser.py
+++ b/apps/h2m_parser.py
@@ -204,7 +204,7 @@ class CLParser(object):
 
         parser.add_argument("--model", type=Path,
                           dest="model_file_name",
-                          default="model/model_1.tflite",
+                          default=None,
                           help="Classification model file in tflite format")
 
         parser.add_argument("--debug", dest="debug", action="store_true",
@@ -299,13 +299,19 @@ class CLParser(object):
         if self.auto_priority:
             voice = True
 
-        self.model_file_name = Path(options.model_file_name)
+        if voice or data or skip:
+            if not options.model_file_name:
+                raise Exception("A model file must be specified (using --model) when classification or auto-priority is enabled.")
+            self.model_file_name = options.model_file_name
+        else:
+            self.model_file_name = None
+
         self.classifier_params = ClassifierParams(
             wanted={'V': voice,
                     'D': data,
                     'S': skip,
             },
-            model_file_name=self.model_file_name.resolve(),
+            model_file_name=self.model_file_name,
         )
 
         if voice or data or skip:

--- a/apps/tests/test_classification.py
+++ b/apps/tests/test_classification.py
@@ -1,0 +1,69 @@
+import pytest
+from pathlib import Path
+from classification import Classifier, ClassifierParams, ClassificationNotWanted
+
+TEST_DIR = Path(__file__).parent
+MODEL_PATH = TEST_DIR.parent / "model" / "model_1.tflite"
+WAV_DIR = TEST_DIR.parent / "test"
+
+@pytest.fixture
+def classifier_params():
+    return ClassifierParams(
+        wanted={'V': True, 'D': True, 'S': True},
+        model_file_name=MODEL_PATH
+    )
+
+def test_classifier_initialization(classifier_params):
+    """Test that the classifier initializes and loads the TFLite model successfully."""
+    with Classifier(classifier_params, audio_rate=8000) as classifier:
+        assert classifier._loaded is True
+        assert classifier.audio_rate == 8000
+        assert classifier._proc is not None
+
+def test_classification_not_wanted():
+    """Test that Classifier raises ClassificationNotWanted if no categories are requested."""
+    params = ClassifierParams(
+        wanted={'V': False, 'D': False, 'S': False},
+        model_file_name=MODEL_PATH
+    )
+    with pytest.raises(ClassificationNotWanted):
+        Classifier(params, audio_rate=8000)
+
+def test_classify_voice(classifier_params):
+    """Test classification of a voice recording."""
+    with Classifier(classifier_params, audio_rate=8000) as classifier:
+        wanted, detected = classifier.is_wanted(str(WAV_DIR / "voice.wav"))
+        assert detected == 'V'
+        assert wanted is True
+
+def test_classify_data(classifier_params):
+    """Test classification of a data recording."""
+    with Classifier(classifier_params, audio_rate=8000) as classifier:
+        wanted, detected = classifier.is_wanted(str(WAV_DIR / "data.wav"))
+        assert detected == 'D'
+        assert wanted is True
+
+def test_classify_skip(classifier_params):
+    """Test classification of a skip/noise recording."""
+    with Classifier(classifier_params, audio_rate=8000) as classifier:
+        wanted, detected = classifier.is_wanted(str(WAV_DIR / "skip.wav"))
+        assert detected == 'S'
+        assert wanted is True
+
+def test_classify_filtering():
+    """Test that files detected as unwanted are filtered out (wanted is False)."""
+    # Configure parameter to only want Voice (V)
+    params = ClassifierParams(
+        wanted={'V': True, 'D': False, 'S': False},
+        model_file_name=MODEL_PATH
+    )
+    with Classifier(params, audio_rate=8000) as classifier:
+        # Voice should return wanted=True
+        wanted_v, detected_v = classifier.is_wanted(str(WAV_DIR / "voice.wav"))
+        assert detected_v == 'V'
+        assert wanted_v is True
+        
+        # Data should return wanted=False (filtered out)
+        wanted_d, detected_d = classifier.is_wanted(str(WAV_DIR / "data.wav"))
+        assert detected_d == 'D'
+        assert wanted_d is False


### PR DESCRIPTION
This PR does the following:

- Moves the Tensorflow machine learning logic into a subprocess
- Makes the the parameter to specify a path to a model required if you use audio classification or auto priority
- Fixes a few typos in the README.md