### PR TITLE
Add optional metadata to saved filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .coverage
-.antigravitycli
+.zed/
+.antigravitycli/
 .venv/
 wav/

--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ options:
   --skip                Record voice
   --model MODEL_FILE_NAME
                         Classification model file in tflite format
+  --file-metadata FILE_METADATA
+                        Comma-separated list of metadata fields to include in
+                        output filenames (e.g. priority,strength)
   --debug               Enable debug file with additional information
                         (ham2mon.log)
 ```
@@ -414,9 +417,40 @@ The model file must be specified using the `--model <path>` option.
 
 At least one of the command line options (`--voice`, `--data`, and `--skip`) must be specified to indicate what recordings are saved.  All others will be discarded.  The classification feature does not impact what is heard over the speaker.  If no options are provided then classification is disabled (this is the default).  If any of the options are provided then record mode (`-w`) will be automatically enabled.
 
-The classification designator will be added after the frequency (e.g. 460.125_V_1698933610.wav for voice).  Only 16-bit audio is currently supported so enable it with `-b 16`.
+The classification designator will be added after the frequency (e.g. 460.1250_V_20231102_140010.123.wav for voice).  Only 16-bit audio is currently supported so enable it with `-b 16`.
 
 No capability is provided to train the model.  Training data will not be provided.  Those interested in training their own model can review [xmits_train](https://gitlab.com/john---/xmits_train) for what was done to train the available model.
+
+## Filename Metadata
+
+When writing transmissions to disk (using `-w` or audio classification options), you can customize the output filenames to include optional metadata by specifying the `--file-metadata` option. This option accepts a comma-separated list of metadata fields to include (e.g. `--file-metadata priority,strength`).
+
+Supported metadata fields:
+
+- `priority`: Appends the priority status of the channel.
+  - Manual priorities are formatted as `P1`, `P2`, etc.
+  - Automatic priorities (dynamically added from auto-priority) are formatted as `PA`.
+- `strength`: Appends the average signal strength (mean RSSI) recorded during the active transmission in dB (e.g., `-48dB`).
+  - Note: The raw FFT spectrum power values are automatically calibrated to a standard negative RSSI range (applying a `-70 dB` calibration offset) to align with standard receiver squelch scales.
+
+> [!NOTE]
+> If a requested metadata field is unavailable when the recording is persisted (e.g., if a channel's priority is not configured, or if signal strength data is `None` because the channel was stopped before any signal power stats could be accumulated), the corresponding segment is completely omitted from the output filename. No placeholders are used.
+
+### Filename Format
+
+The metadata fields are appended in a structured sequence using underscores (`_`) as delimiters:
+`<frequency>[_classification][_priority][_strength]_<timestamp>.wav`
+
+Examples:
+
+- Standard (no metadata): `460.1250_20231102_140010.123.wav`
+- With priority requested: `460.1250_P1_20231102_140010.123.wav`
+- With priority and strength requested: `460.1250_P1_-48dB_20231102_140010.123.wav`
+- With auto-priority and strength requested: `460.1250_PA_-45dB_20231102_140010.123.wav`
+- With strength requested but unavailable (e.g. no signal stats): `460.1250_20231102_140010.123.wav`
+
+If audio classification is enabled (e.g., via `--voice`, which adds a classification segment such as `V` or `D`), it will be inserted directly after the frequency:
+- With classification, priority, and strength: `460.1250_V_P1_-48dB_20231102_140010.123.wav`
 
 ## Ham2mon Development
 

--- a/apps/demodulators/AM.py
+++ b/apps/demodulators/AM.py
@@ -57,12 +57,15 @@ class TunerDemodAM(BaseTuner):
 
     def __init__(self, samp_rate: int, audio_rate: int, record: bool,
                  audio_bps: int, min_recording: float, classify: Classifier | None,
-                 notify_scanner: Callable):
+                 notify_scanner: Callable,
+                 file_metadata: list[str] | None = None,
+                 get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None):
         gr.hier_block2.__init__(self, "TunerDemodAM",
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex),
                                 gr.io_signature(1, 1, gr.sizeof_float))
 
-        super().__init__(classify, notify_scanner)
+        super().__init__(classify, notify_scanner, file_metadata=file_metadata, get_priority_info=get_priority_info)
+
 
         # Default values
         self.center_freq = 0

--- a/apps/demodulators/BaseTuner.py
+++ b/apps/demodulators/BaseTuner.py
@@ -22,7 +22,9 @@ class BaseTuner(gr.hier_block2):
 
     channel: int = 0  # incremented for each new demodulator
 
-    def __init__(self, classify: Classifier | None, notify_scanner: Callable) -> None:
+    def __init__(self, classify: Classifier | None, notify_scanner: Callable,
+                 file_metadata: list[str] | None = None,
+                 get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None) -> None:
         BaseTuner.channel += 1
 
         # Default values
@@ -34,12 +36,16 @@ class BaseTuner(gr.hier_block2):
         self.log_task: Task | None = None
         self.center_freq: int
 
+        self.file_metadata: list[str] = file_metadata if file_metadata is not None else []
+        self.get_priority_info = get_priority_info
+
+
     def set_last_heard(self, a_time: float) -> None:
         self.last_heard = a_time
         # channel_log active channel if at required interval
         # alternately use a timer or something that is created on demod start
 
-    async def set_center_freq(self, center_freq: int, rf_center_freq: int) -> None:
+    async def set_center_freq(self, center_freq: int, rf_center_freq: int, avg_signal: int | None = None) -> None:
         """Sets baseband center frequency and file name
 
         Sets baseband center frequency of frequency translating FIR filter
@@ -50,13 +56,14 @@ class BaseTuner(gr.hier_block2):
         Args:
             center_freq (int): Baseband center frequency in Hz
             rf_center_freq (int): RF center in Hz (for file name)
+            avg_signal (int, optional): Calculated average signal strength in dB
         """
         # address completed transmissions
         results: ChannelMessage | None
         if self.record:
             # Move file from tmp directory if it is long enough
             # and classified appropriately
-            results = self._persist_wavfile(rf_center_freq)   # also get channel_log information
+            results = self._persist_wavfile(rf_center_freq, avg_signal=avg_signal)   # also get channel_log information
         elif self.center_freq != 0:
             # not recording files and center_freq has changed
             results = ChannelMessage(state='off',
@@ -67,7 +74,7 @@ class BaseTuner(gr.hier_block2):
         else:
             # center_freq is 0
             results = None
-            
+
         await self.notify_scanner(results)  # off events or nothing to note
 
         # Set the frequency of the tuner
@@ -93,63 +100,56 @@ class BaseTuner(gr.hier_block2):
                                                          channel=self.channel))
 
     def set_file_name(self, rf_center_freq: int) -> None:
-        # Use frequency and time stamp for file name
-        tstamp = time.strftime("%Y%m%d_%H%M%S", time.localtime()) + "{:.3f}".format(self.time_stamp%1)[1:]
-        file_freq = (rf_center_freq + self.center_freq)/1E6  # TODO: use utilities function
-        file_freq = np.round(file_freq, 4)
-        # avoid "chatter" of possibly unwanted files by working in tmp dir initially
-        self.file_name = f'wav/tmp/{file_freq:.4f}_{tstamp}.wav'
+        self.tstamp_str = time.strftime("%Y%m%d_%H%M%S", time.localtime()) + "{:.3f}".format(self.time_stamp % 1)[1:]
+        file_freq = (rf_center_freq + self.center_freq) / 1E6
+        self.freq_str = f"{np.round(file_freq, 4):.4f}"
+        self.file_name = f'wav/tmp/{self.freq_str}_{self.tstamp_str}.wav'
 
-    def _persist_wavfile(self, rf_center_freq: int) -> ChannelMessage | None:
-        """Save the current wavfile if duration long enough"""
-        if (not self.file_name or
-                self.file_name is None):
-            # currently recording and transmission started
+    def _persist_wavfile(self, rf_center_freq: int, avg_signal: int | None = None) -> ChannelMessage | None:
+        if not self.file_name:
             return None
-        
+
         self.blocks_wavfile_sink.close()
 
-        # base message used for channel log
         xmit_msg = ChannelMessage(state='off',
-                                  rf=baseband_to_frequency(
-                                      self.center_freq, rf_center_freq),
-                                  bb=self.center_freq,
-                                  channel=self.channel)
+                                rf=baseband_to_frequency(self.center_freq, rf_center_freq),
+                                bb=self.center_freq,
+                                channel=self.channel,
+                                signal_db=avg_signal)
 
-        # Delete short wavfiles otherwise move ones that are long enough
-        min_size = 44 + self.audio_bps*1000 * self.min_recording
+        min_size = 44 + self.audio_bps * 1000 * self.min_recording
         if os.stat(self.file_name).st_size <= min_size:
             os.unlink(self.file_name)
             xmit_msg.detail = 'Discarded short recording'
             return xmit_msg
 
-        # If not classifying then move from tmp directory
-        if not self.classify:
-            name = self.file_name.replace('tmp/', '')
-            os.rename(self.file_name, name)
-            xmit_msg.file = name
-            return xmit_msg
+        # Classify if enabled — determines whether file is wanted and adds label
+        classification: str | None = None
+        if self.classify:
+            is_wanted, classification = self.classify.is_wanted(self.file_name)
+            xmit_msg.classification = classification
+            if not is_wanted:
+                os.unlink(self.file_name)
+                xmit_msg.detail = 'Discarded unwanted classification'
+                return xmit_msg
 
-        # If user wants file of this classification
-        # then move from tmp directory and rename
-        # otherwise delete it
-        (is_wanted, classification) = self.classify.is_wanted(self.file_name)
-        xmit_msg.classification = classification
-        if  is_wanted:
-            name = self.file_name.replace('tmp/', '')
-            name = name.replace('.wav', '_' + classification + '.wav')
-            os.rename(self.file_name, name)
-            
-            # if using recent python3 have self.file_name be a Path
-            # new_name = PurePath(self.file_name)
-            # name = f'wav/{new_name.stem}_{is_wanted}{new_name.suffix}'
-            xmit_msg.file = name
-            return xmit_msg
-        else:
-            os.unlink(self.file_name)
-            xmit_msg.detail = 'Discarded unwanted classification'
-            return  xmit_msg
-    
+        # Build final filename from stored components
+        name_parts: list[str] = [self.freq_str]
+        if classification is not None:
+            name_parts.append(classification)
+        if 'priority' in self.file_metadata and self.get_priority_info:
+            priority, is_auto = self.get_priority_info(self.center_freq)
+            if priority is not None:
+                name_parts.append("PA" if is_auto else f"P{priority}")
+        if 'strength' in self.file_metadata and avg_signal is not None:
+            name_parts.append(f"{avg_signal}dB")
+        name_parts.append(self.tstamp_str)
+
+        new_name = f'wav/{"_".join(name_parts)}.wav'
+        os.rename(self.file_name, new_name)
+        xmit_msg.file = new_name
+        return xmit_msg
+
     def set_squelch(self, squelch_db: int) -> None:
         """Sets the threshold for both squelches
 

--- a/apps/demodulators/NBFM.py
+++ b/apps/demodulators/NBFM.py
@@ -54,12 +54,15 @@ class TunerDemodNBFM(BaseTuner):
 
     def __init__(self, samp_rate: int, audio_rate: int, record: bool,
                  audio_bps: int, min_recording: float, classify: Classifier | None,
-                 notify_scanner: Callable):
+                 notify_scanner: Callable,
+                 file_metadata: list[str] | None = None,
+                 get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None):
         gr.hier_block2.__init__(self, "TunerDemodNBFM",
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex),
                                 gr.io_signature(1, 1, gr.sizeof_float))
 
-        super().__init__(classify, notify_scanner)
+        super().__init__(classify, notify_scanner, file_metadata=file_metadata, get_priority_info=get_priority_info)
+
 
         # Default values
         self.center_freq = 0

--- a/apps/demodulators/WBFM.py
+++ b/apps/demodulators/WBFM.py
@@ -68,13 +68,16 @@ class TunerDemodWBFM(BaseTuner):
 
     def __init__(self, samp_rate: int, audio_rate: int, record: bool,
                  audio_bps: int, min_recording: float, classify: Classifier | None,
-                 notify_scanner: Callable, ctcss_filter: bool=False, ctcss_tone_block: bool=False):
+                 notify_scanner: Callable, ctcss_filter: bool=False, ctcss_tone_block: bool=False,
+                 file_metadata: list[str] | None = None,
+                 get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None):
 
         gr.hier_block2.__init__(self, "TunerDemodWBFM",
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex),
                                 gr.io_signature(1, 1, gr.sizeof_float))
 
-        super().__init__(classify, notify_scanner)
+        super().__init__(classify, notify_scanner, file_metadata=file_metadata, get_priority_info=get_priority_info)
+
         
         # Default values
         self.center_freq = 0

--- a/apps/frequency_manager.py
+++ b/apps/frequency_manager.py
@@ -184,6 +184,7 @@ class ChannelMessage(FrequencyInfo):
     file: Optional[str] = None
     classification: Optional[str] = None
     detail: Optional[str] = None
+    signal_db: Optional[int] = None
 
 
 FrequencyList: TypeAlias = list[ConfigFrequency]
@@ -370,6 +371,31 @@ class FrequencyManager:
                         lowest = priority
 
         return lowest
+
+    def get_priority_info(self, bb: int) -> tuple[int | None, bool]:
+        '''
+        Compare the channel to frequency and range priorities and return both
+        the priority level and whether it was automatically assigned.
+
+        Args:
+            bb (int): Baseband frequency of tuned channel
+        '''
+        for frequency in self.frequencies:
+            priority = frequency.get_priority_at(bb)
+            if priority is not None and frequency.single:
+                return priority, frequency.mode == 'add'
+
+        lowest: int | None = None
+        is_auto = False
+        for frequency in self.frequencies:
+            priority = frequency.get_priority_at(bb)
+            if priority is not None and not frequency.single:
+                if lowest is None or priority < lowest:
+                    lowest = priority
+                    is_auto = frequency.mode == 'add'
+
+        return lowest, is_auto
+
 
     def is_higher_priority(self, channel_bb: int, demod_freq: int) -> bool:
         '''

--- a/apps/h2m_parser.py
+++ b/apps/h2m_parser.py
@@ -67,7 +67,7 @@ class CLParser(object):
         parser.add_argument("-f", "--freq", type=str, dest="freq_spec",
                           nargs='+', default=["146"],
                           help="Hardware RF center frequency or range in Mhz")
-        
+
         parser.add_argument("--quiet_timeout", type=int,
                           dest="quiet_timeout", default=12,
                           help="Timeout when there is no activity")
@@ -172,7 +172,7 @@ class CLParser(object):
         parser.add_argument("-b", "--bps", type=int, dest="audio_bps",
                           default=16,
                           help="Audio bit depth (bps)")
-        
+
         parser.add_argument("-M", "--max_db", type=float, dest="max_db",
                           default=50,
                           help="Spectrum window max dB for display")
@@ -195,12 +195,12 @@ class CLParser(object):
 
         parser.add_argument("--voice", dest="voice", action="store_true",
                           help="Record voice")
-        
+
         parser.add_argument("--data", dest="data", action="store_true",
                           help="Record voice")
 
         parser.add_argument("--skip", dest="skip", action="store_true",
-                          help="Record voice")  
+                          help="Record voice")
 
         parser.add_argument("--model", type=Path,
                           dest="model_file_name",
@@ -208,7 +208,11 @@ class CLParser(object):
                           help="Classification model file in tflite format")
 
         parser.add_argument("--debug", dest="debug", action="store_true",
-                          help="Enable debug file with additional information (ham2mon.log)")              
+                          help="Enable debug file with additional information (ham2mon.log)")
+
+        parser.add_argument("--file-metadata", type=str,
+                          dest="file_metadata", default="",
+                          help="Comma-separated list of metadata fields to include in output filenames (e.g. priority,strength)")
 
         options = parser.parse_args()
         self.print_help = parser.print_help
@@ -237,7 +241,7 @@ class CLParser(object):
                     if upper_freq:
                         upper_freq = int(float(upper_freq)*1E6)
                 except ValueError as err:
-                    raise Exception(f'Frequencies must be integers: {err}')
+                    parser.error(f'Frequencies must be integers: {err}')
                 range_params.append(FrequencyRangeParams(lower_freq=lower_freq, upper_freq=upper_freq))
             except ValueError:
                 # there is a single value provided
@@ -245,13 +249,13 @@ class CLParser(object):
                     single_freq = int(float(freq_entry)*1E6)
                     single_params.append(FrequencySingleParams(freq=single_freq))
                 except ValueError as err:
-                    raise Exception(f'Frequency must be integers: {err}')
+                    parser.error(f'Frequency must be integers: {err}')
 
         self.frequency_params =  FrequencyGroup(ranges=range_params, singles=single_params,
                                                 sample_rate=self.ask_samp_rate,
                                                 quiet_timeout=int(options.quiet_timeout),
                                                 active_timeout=int(options.active_timeout))
-        
+
         self.gains = [
             { "name": "RF", "value": float(options.rf_gain_db) },
             { "name": "LNA","value": float(options.lna_gain_db) },
@@ -292,7 +296,7 @@ class CLParser(object):
         self.min_recording = float(options.min_recording)
         self.max_recording = float(options.max_recording)
 
-        voice = bool(options.voice)        
+        voice = bool(options.voice)
         data = bool(options.data)
         skip = bool(options.skip)
 
@@ -318,6 +322,16 @@ class CLParser(object):
             self.record = True
 
         self.debug = bool(options.debug)
+
+        self.file_metadata: list[str] = []
+        if options.file_metadata:
+            fields = [f.strip().lower() for f in options.file_metadata.split(',')]
+            valid_fields = {'priority', 'strength'}
+            for field in fields:
+                if field not in valid_fields:
+                    parser.error(f"Unsupported metadata field: '{field}'. Supported fields: priority, strength")
+            self.file_metadata = fields
+
 
 def main():
     """Test the parser"""
@@ -368,4 +382,3 @@ if __name__ == '__main__':
         main()
     except KeyboardInterrupt:
         pass
-

--- a/apps/ham2mon.py
+++ b/apps/ham2mon.py
@@ -138,13 +138,15 @@ class MyDisplay():
         classifier_params = PARSER.classifier_params
 
         auto_priority = PARSER.auto_priority
+        file_metadata = PARSER.file_metadata
 
         scanner = scnr.Scanner(ask_samp_rate, num_demod, type_demod, hw_args,
                                freq_correction, record, frequency_configuration,
                                channel_log_params,
                                play, audio_bps, channel_spacing,
                                frequency_params, min_recording, max_recording,
-                               classifier_params, auto_priority, agc)
+                               classifier_params, auto_priority, agc,
+                               file_metadata=file_metadata)
 
         await scanner.load_frequencies()
         # Set the parameters
@@ -157,7 +159,7 @@ class MyDisplay():
 
     def center_freq_changed(self):
         '''
-        Callback that notifies when the scanner changed 
+        Callback that notifies when the scanner changed
         the center frequency.  This occurs when range scanning.
         '''
         self.rxwin.center_freq = self.scanner.center_freq

--- a/apps/receiver.py
+++ b/apps/receiver.py
@@ -55,7 +55,8 @@ class Receiver(gr.top_block):
                  hw_args: str, freq_correction: int, record: bool, play: bool,
                  audio_bps: int, min_recording: float,
                  classifier_params: ClassifierParams, notify_scanner: Callable,
-                 agc: bool):
+                 agc: bool, file_metadata: list[str] | None = None,
+                 get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None):
 
         # Call the initialization method from the parent class
         gr.top_block.__init__(self, "Receiver")
@@ -144,12 +145,14 @@ class Receiver(gr.top_block):
         try:
           classifier = Classifier(classifier_params, audio_rate)
         except ClassificationNotWanted:
-            classifier = None   
+            classifier = None
         except Exception as error:
             msg = f'Could not create classifier ({error})'
             logging.error(msg)
             raise Exception(msg)
 
+        self.file_metadata = file_metadata if file_metadata is not None else []
+        self.get_priority_info = get_priority_info
 
         # -----------Flow for Demod--------------
 
@@ -163,23 +166,30 @@ class Receiver(gr.top_block):
                                                         audio_bps,
                                                         min_recording,
                                                         classifier,
-                                                        notify_scanner))
+                                                        notify_scanner,
+                                                        file_metadata=self.file_metadata,
+                                                        get_priority_info=self.get_priority_info))
             elif type_demod == 1:
                 self.demodulators.append(TunerDemodAM(self.samp_rate,
                                                       audio_rate, record,
                                                       audio_bps,
                                                       min_recording,
                                                       classifier,
-                                                      notify_scanner))
+                                                      notify_scanner,
+                                                      file_metadata=self.file_metadata,
+                                                      get_priority_info=self.get_priority_info))
             elif type_demod == 2:
                 self.demodulators.append(TunerDemodWBFM(self.samp_rate,
                                                         audio_rate, record,
                                                         audio_bps,
                                                         min_recording,
                                                         classifier,
-                                                        notify_scanner))
+                                                        notify_scanner,
+                                                        file_metadata=self.file_metadata,
+                                                        get_priority_info=self.get_priority_info))
             else:
                 raise Exception(f'Invalid demodulator type: {type_demod}')
+
 
         if play:
             # Create an adder
@@ -337,7 +347,7 @@ async def main():
         if msg is None:
             return
         print(f'Opened channel {msg.channel-1}')  # channel is a 1 based representation of the demod
-    
+
     receiver = Receiver(ask_samp_rate, num_demod, type_demod, hw_args,
                         freq_correction, record, play, audio_bps,
                         min_recording, classifier_params, print_to_screen, agc)

--- a/apps/scanner.py
+++ b/apps/scanner.py
@@ -80,7 +80,8 @@ class Scanner(object):
                  frequency_params: FrequencyGroup=FrequencyGroup(sample_rate=int(4E6)),
                  min_recording: float=0, max_recording: float=0,
                  classifier_params: ClassifierParams=None,
-                 auto_priority: bool=False, agc: bool=False):
+                 auto_priority: bool=False, agc: bool=False,
+                 file_metadata: list[str] | None=None):
 
         # Default values
         self.squelch_db = -60
@@ -104,14 +105,20 @@ class Scanner(object):
         self.max_recording = max_recording
         self.xmit_stats: dict[float, ClassificationCount] = {}
         self.auto_priority = auto_priority
+        self.file_metadata = file_metadata if file_metadata is not None else []
+        self._demod_signal_stats: dict[int, tuple[float, int]] = {i: (0.0, 0) for i in range(num_demod)}
 
         self.channel_logger = ChannelLogger.get_logger(channel_log_params)
+
+        self.frequency_manager = FrequencyManager(frequency_configuration, self.channel_spacing)
 
         # Create receiver object
         self.receiver = recvr.Receiver(ask_samp_rate, num_demod, type_demod,
                                        hw_args, freq_correction, record, play,
                                        audio_bps, min_recording, classifier_params,
-                                       self.got_channel_activity, agc)
+                                       self.got_channel_activity, agc,
+                                       file_metadata=self.file_metadata,
+                                       get_priority_info=self.frequency_manager.get_priority_info)
 
         # Get the hardware sample rate
         self.samp_rate = self.receiver.samp_rate
@@ -130,7 +137,6 @@ class Scanner(object):
         self.step = self.frequency_provider.step
         self.steps = self.frequency_provider.steps
 
-        self.frequency_manager = FrequencyManager(frequency_configuration, self.channel_spacing)
         # self.frequencies = self.frequency_manager.frequencies
 
         # Start the receiver and wait for samples to accumulate
@@ -160,6 +166,14 @@ class Scanner(object):
         """
 
         raw_channels = self._get_raw_channels()
+
+        # Accumulate signal levels for active demodulators if requested
+        if 'strength' in self.file_metadata:
+            for idx, demodulator in enumerate(self.receiver.demodulators):
+                if demodulator.center_freq != 0:
+                    strength = self._get_signal_strength(demodulator.center_freq)
+                    curr_sum, curr_count = self._demod_signal_stats.get(idx, (0.0, 0))
+                    self._demod_signal_stats[idx] = (curr_sum + strength, curr_count + 1)
 
         self._channels = self._add_metadata(raw_channels)
 
@@ -197,6 +211,19 @@ class Scanner(object):
 
         return channels
 
+    def _get_signal_strength(self, bb: int) -> float:
+        if self.spectrum is None or len(self.spectrum) == 0:
+            return -100.0
+
+        bin_idx = int(np.round((bb * len(self.spectrum) / self.samp_rate) + len(self.spectrum) / 2))
+        bin_idx = max(0, min(len(self.spectrum) - 1, bin_idx))
+
+        power = self.spectrum[bin_idx]
+        if power <= 0:
+            return -200.0
+
+        return 10.0 * np.log10(power) - 70.0
+
     async def _process_current_demodulators(self, channels: ChannelList) -> None:
 
         the_now = time.time()
@@ -207,13 +234,19 @@ class Scanner(object):
 
             # Stop locked out demodulator (lockout was just added via UI)
             if self.frequency_manager.locked_out(demodulator.center_freq):
-                await demodulator.set_center_freq(0, self.center_freq)
+                curr_sum, curr_count = self._demod_signal_stats.get(idx, (0.0, 0))
+                avg_signal = int(np.round(curr_sum / curr_count)) if curr_count > 0 else None
+                self._demod_signal_stats[idx] = (0.0, 0)
+                await demodulator.set_center_freq(0, self.center_freq, avg_signal=avg_signal)
                 continue
 
             # Stop the demodulator if not being scanned and outside the hang time
             if any(channel.hanging and channel.bb == demodulator.center_freq for channel in channels):
                 if the_now - demodulator.last_heard > self.hang_time:
-                    await demodulator.set_center_freq(0, self.center_freq)
+                    curr_sum, curr_count = self._demod_signal_stats.get(idx, (0.0, 0))
+                    avg_signal = int(np.round(curr_sum / curr_count)) if curr_count > 0 else None
+                    self._demod_signal_stats[idx] = (0.0, 0)
+                    await demodulator.set_center_freq(0, self.center_freq, avg_signal=avg_signal)
             else:
                 demodulator.set_last_heard(the_now)
 
@@ -221,7 +254,10 @@ class Scanner(object):
             if self.max_recording > 0:
                 if time.time() - demodulator.time_stamp >= self.max_recording:
                     # clear the demodulator to reset file
-                    await demodulator.set_center_freq(0, self.center_freq)
+                    curr_sum, curr_count = self._demod_signal_stats.get(idx, (0.0, 0))
+                    avg_signal = int(np.round(curr_sum / curr_count)) if curr_count > 0 else None
+                    self._demod_signal_stats[idx] = (0.0, 0)
+                    await demodulator.set_center_freq(0, self.center_freq, avg_signal=avg_signal)
 
     async def _assign_channels_to_demodulators(self, channels: ChannelList) -> None:
 
@@ -235,9 +271,16 @@ class Scanner(object):
                     demodulator = self.receiver.demodulators[idx]
                     # If channel is higher priority than what is being demodulated
                     if self.frequency_manager.is_higher_priority(channel.bb, demodulator.center_freq):
+                        # Calculate avg_signal for the completed transmission if it was actively running
+                        avg_signal = None
+                        if demodulator.center_freq != 0:
+                            curr_sum, curr_count = self._demod_signal_stats.get(idx, (0.0, 0))
+                            avg_signal = int(np.round(curr_sum / curr_count)) if curr_count > 0 else None
+                        self._demod_signal_stats[idx] = (0.0, 0)
+
                         # Assigning channel to empty demodulator
                         await demodulator.set_center_freq(
-                            channel.bb, self.center_freq)
+                            channel.bb, self.center_freq, avg_signal=avg_signal)
                         break
                     else:
                         pass
@@ -426,8 +469,11 @@ class Scanner(object):
 
     async def clean_up(self) -> None:
         # cleanup terminating all demodulators
-        for demod in self.receiver.demodulators:
-            await demod.set_center_freq(0, self.center_freq)
+        for idx, demod in enumerate(self.receiver.demodulators):
+            curr_sum, curr_count = self._demod_signal_stats.get(idx, (0.0, 0))
+            avg_signal = int(np.round(curr_sum / curr_count)) if curr_count > 0 else None
+            self._demod_signal_stats[idx] = (0.0, 0)
+            await demod.set_center_freq(0, self.center_freq, avg_signal=avg_signal)
 
 
 async def main() -> None:

--- a/apps/tests/test_filename_generation.py
+++ b/apps/tests/test_filename_generation.py
@@ -1,0 +1,275 @@
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Callable, Generator, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+from demodulators.BaseTuner import BaseTuner
+from gnuradio import gr  # type: ignore
+
+# Mock tensorflow to allow importing classification.py/BaseTuner without tensorflow installed
+sys.modules["tensorflow"] = MagicMock()
+
+
+class MockTuner(BaseTuner):
+    def __init__(
+        self,
+        classify: None,
+        notify_scanner: Callable,
+        file_metadata: list[str] | None = None,
+        get_priority_info: Callable[[int], Tuple[int | None, bool]] | None = None,
+    ) -> None:
+        gr.hier_block2.__init__(
+            self,
+            "MockTuner",
+            gr.io_signature(1, 1, gr.sizeof_gr_complex),
+            gr.io_signature(1, 1, gr.sizeof_float),
+        )
+        super().__init__(classify, notify_scanner, file_metadata, get_priority_info)
+        self.record = True
+        self.audio_bps = 8
+        self.min_recording = 0.0
+        self.center_freq = 1000
+
+        class MockWavSink:
+            def close(self) -> None:
+                pass
+
+        self.blocks_wavfile_sink = MockWavSink()
+
+    def set_temp_file(self, temp_file: str) -> None:
+        """Simulate the state set_file_name would establish for a given tmp path."""
+        basename = os.path.basename(temp_file).removesuffix(".wav")
+        self.freq_str, self.tstamp_str = basename.split("_", 1)
+        self.file_name = temp_file
+
+
+@pytest.fixture(autouse=True)
+def setup_teardown_wav_dirs() -> Generator[None, None, None]:
+    # Helper to clean up only test wav files created by tests in this module (using the test timestamp)
+    def cleanup_test_files():
+        for f in Path("wav").glob("*_20260531_160622.345.wav"):
+            if f.is_file():
+                f.unlink()
+        if os.path.exists("wav/tmp"):
+            shutil.rmtree("wav/tmp")
+
+    # Clean up before run to ensure clean state
+    cleanup_test_files()
+    os.makedirs("wav/tmp", exist_ok=True)
+
+    yield
+
+    # Clean up after run
+    cleanup_test_files()
+
+
+def test_persist_filename_no_metadata() -> None:
+    # Test default behaviour without any metadata requested
+    tuner = MockTuner(None, lambda msg: None, file_metadata=[])
+
+    # Simulate a recording file
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)  # write dummy bytes
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_20260531_160622.345.wav")
+
+
+def test_persist_filename_with_priority() -> None:
+    # Mock priority callback
+    def get_priority_info(bb: int) -> Tuple[int | None, bool]:
+        return 2, False  # Priority 2, not auto
+
+    tuner = MockTuner(
+        None,
+        lambda msg: None,
+        file_metadata=["priority"],
+        get_priority_info=get_priority_info,
+    )
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_P2_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_P2_20260531_160622.345.wav")
+
+
+def test_persist_filename_with_auto_priority() -> None:
+    def get_priority_info(bb: int) -> Tuple[int | None, bool]:
+        return 1, True  # Priority 1, auto
+
+    tuner = MockTuner(
+        None,
+        lambda msg: None,
+        file_metadata=["priority"],
+        get_priority_info=get_priority_info,
+    )
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_PA_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_PA_20260531_160622.345.wav")
+
+
+def test_persist_filename_with_strength() -> None:
+    tuner = MockTuner(None, lambda msg: None, file_metadata=["strength"])
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000, avg_signal=-50)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_-50dB_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_-50dB_20260531_160622.345.wav")
+
+
+def test_persist_filename_with_priority_and_strength() -> None:
+    def get_priority_info(bb: int) -> Tuple[int | None, bool]:
+        return 1, False
+
+    tuner = MockTuner(
+        None,
+        lambda msg: None,
+        file_metadata=["priority", "strength"],
+        get_priority_info=get_priority_info,
+    )
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000, avg_signal=-51)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_P1_-51dB_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_P1_-51dB_20260531_160622.345.wav")
+
+
+def test_persist_filename_no_metadata_with_classification() -> None:
+    # Test new breaking change naming format when classification is enabled and no metadata flags are specified
+    class MockClassifier:
+        def is_wanted(self, filename: str) -> Tuple[bool, str]:
+            return True, "V"
+
+    tuner = MockTuner(MockClassifier(), lambda msg: None, file_metadata=[])
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_V_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_V_20260531_160622.345.wav")
+
+
+def test_persist_filename_no_active_file() -> None:
+    tuner = MockTuner(None, lambda msg: None, file_metadata=[])
+    tuner.file_name = None
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is None
+
+
+def test_persist_filename_short_recording() -> None:
+    tuner = MockTuner(None, lambda msg: None, file_metadata=[])
+    tuner.min_recording = 5.0  # min_size will be 44 + 8 * 1000 * 5.0 = 40044 bytes
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)  # 100 bytes is shorter than min_size
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file is None
+    assert msg.detail == "Discarded short recording"
+    assert not os.path.exists(temp_file)
+
+
+def test_persist_filename_unwanted_classification() -> None:
+    # Test discarding when classification indicates it is unwanted (using 'S' for static/noise)
+    class MockClassifier:
+        def is_wanted(self, filename: str) -> Tuple[bool, str]:
+            return False, "S"
+
+    tuner = MockTuner(MockClassifier(), lambda msg: None, file_metadata=[])
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file is None
+    assert msg.classification == "S"
+    assert msg.detail == "Discarded unwanted classification"
+    assert not os.path.exists(temp_file)
+
+
+def test_persist_filename_priority_none() -> None:
+    # Test that when 'priority' metadata is requested, but get_priority_info returns priority=None
+    def get_priority_info(bb: int) -> Tuple[int | None, bool]:
+        return None, False
+
+    tuner = MockTuner(
+        None,
+        lambda msg: None,
+        file_metadata=["priority"],
+        get_priority_info=get_priority_info,
+    )
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_20260531_160622.345.wav")
+
+
+def test_persist_filename_strength_metadata_none_signal() -> None:
+    # Test that when 'strength' metadata is requested, but avg_signal is None
+    tuner = MockTuner(None, lambda msg: None, file_metadata=["strength"])
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000, avg_signal=None)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_20260531_160622.345.wav")
+

--- a/apps/tests/test_frequency_manager.py
+++ b/apps/tests/test_frequency_manager.py
@@ -793,3 +793,38 @@ async def test_fail_change_nonexistant_range(fm_empty):
 
     with pytest.raises(ValueError, match='not found in frequencies list'):
         await fm_empty.change(entry)
+
+
+@pytest.mark.asyncio
+async def test_get_priority_info(fm_empty):
+    CENTER_FREQ = 500e6  # 500 MHz
+    fm_empty.set_center(CENTER_FREQ)
+
+    # 1. Add a single frequency with priority 1, mode='add' (auto-priority)
+    await fm_empty.add({'single': 500.01, 'priority': 1, 'label': 'Auto Priority Single', 'mode': 'add'})
+
+    # 2. Add a single frequency with priority 1, normal (not auto)
+    await fm_empty.add({'single': 500.02, 'priority': 1, 'label': 'Priority Single'})
+
+    # 3. Add a range frequency with priority 3
+    await fm_empty.add({'lo': 500.03, 'hi': 500.05, 'priority': 3, 'label': 'Range Priority'})
+
+    # Test single auto-priority: +10 kHz (10000 Hz)
+    p, is_auto = fm_empty.get_priority_info(10000)
+    assert p == 1
+    assert is_auto is True
+
+    # Test single normal priority: +20 kHz (20000 Hz)
+    p, is_auto = fm_empty.get_priority_info(20000)
+    assert p == 1
+    assert is_auto is False
+
+    # Test range priority: +40 kHz (40000 Hz)
+    p, is_auto = fm_empty.get_priority_info(40000)
+    assert p == 3
+    assert is_auto is False
+
+    # Test non-priority channel: +60 kHz (60000 Hz)
+    p, is_auto = fm_empty.get_priority_info(60000)
+    assert p is None
+    assert is_auto is False

--- a/apps/tests/test_scanner.py
+++ b/apps/tests/test_scanner.py
@@ -1,0 +1,38 @@
+from typing import Callable
+import numpy as np
+from scanner import Scanner
+
+def test_scanner_get_signal_strength_offset() -> None:
+    class DummyScanner:
+        samp_rate: int
+        spectrum: np.ndarray
+        _get_signal_strength: Callable[[int], float]
+
+    scanner = DummyScanner()
+    scanner.samp_rate = 4000000
+    # Bind the real _get_signal_strength method to our dummy instance
+    scanner._get_signal_strength = Scanner._get_signal_strength.__get__(
+        scanner, DummyScanner
+    )
+
+    # 1. Test weak signal: linear power of 10.0 (10 dB raw power)
+    # Calibrated: 10 dB - 70 dB = -60 dB
+    scanner.spectrum = np.array([10.0])
+    val = scanner._get_signal_strength(0)
+    assert np.isclose(val, -60.0)
+
+    # 2. Test strong signal: linear power of 1000.0 (30 dB raw power)
+    # Calibrated: 30 dB - 70 dB = -40 dB
+    scanner.spectrum = np.array([1000.0])
+    val = scanner._get_signal_strength(0)
+    assert np.isclose(val, -40.0)
+
+    # 3. Test empty/None spectrum: should return -100.0
+    scanner.spectrum = np.empty(0)
+    val = scanner._get_signal_strength(0)
+    assert np.isclose(val, -100.0)
+
+    # 4. Test zero/negative power: should return -200.0
+    scanner.spectrum = np.array([0.0])
+    val = scanner._get_signal_strength(0)
+    assert np.isclose(val, -200.0)


### PR DESCRIPTION
This change will add additional optional metadata fields to saved wav filenames.  See the [README.md](https://github.com/john-/ham2mon/tree/add-optional-metadata-to-filenames#filename-metadata) for details.

*Note:* There were also changes made to README.md to get the filenames in the examples to match the application code.  These should have been changed as a result of a prior commit and are not the result of this PR.