### PR TITLE
improve debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,14 @@ options:
   --file-metadata FILE_METADATA
                         Comma-separated list of metadata fields to include in
                         output filenames (e.g. priority,strength)
-  --debug               Enable debug file with additional information
-                        (ham2mon.log)
+  --log-level {debug,info,warn,error}
+                        Log verbosity level; only has effect if --log-dest is
+                        not 'none' (default: warn)
+  --log-dest {none,file,syslog,stderr}
+                        Log destination (default: none)
+  --log-file LOG_FILE
+                        Log file path when --log-dest is 'file' (default:
+                        script_dir/ham2mon.log)
 ```
 Note: The available gains are hardware specific.  The user interface will list the gains available based on hardware option supplied to ham2mon.
 
@@ -392,7 +398,7 @@ A type may support a target through the `--log_target` option.  In the case of t
 
 An activity log entry is written every 15 seconds (by default).  This can be changed with `--log_active_timeout`.  Set this to 0 to disable activity logging (channel on/off messages will still occur).
 
-If `debug` is selected as logging type than channel events can be viewed when the `--debug` option is also selected on the command line.
+If `debug` is selected as logging type then channel events can be viewed when the `--log-level=debug` option is also selected on the command line.
 
 See [json-server example](doc/json-server_example.md) for one way this can be used.
 
@@ -406,7 +412,7 @@ If the number of voice transmissions is less than the number of data/skip transm
 Auto priority currently requires audio classification so `--voice` will automatically be enabled if this option is selected.  Therefore, `--model` must also be specified when using auto priority.
 
 ## Logging
-Application logging events are written to `ham2mon.log`.  These are separate from channel logging events (-L option) and are intended for application debugging.
+Application logging events can be configured using the `--log-level` and `--log-dest` options. These are separate from channel logging events (-L option) and are intended for application debugging. By default, logging is disabled (`--log-dest=none`). If enabled with `--log-dest=file`, logs are written to `ham2mon.log` (or a custom path specified with `--log-file`).
 
 ## Audio Classification
 *Note: The classification is not 100% accurate.  There will be both false positives and negatives.*

--- a/apps/h2m_parser.py
+++ b/apps/h2m_parser.py
@@ -206,9 +206,19 @@ class CLParser(object):
                           dest="model_file_name",
                           default=None,
                           help="Classification model file in tflite format")
+        parser.add_argument("--log-level", dest="log_level",
+                          choices=["debug", "info", "warn", "error"],
+                          default="warn",
+                          help="Log verbosity level; only has effect if --log-dest is not 'none' (default: warn)")
 
-        parser.add_argument("--debug", dest="debug", action="store_true",
-                          help="Enable debug file with additional information (ham2mon.log)")
+        parser.add_argument("--log-dest", dest="log_dest",
+                          choices=["none", "file", "syslog", "stderr"],
+                          default="none",
+                          help="Log destination (default: none)")
+
+        parser.add_argument("--log-file", dest="log_file",
+                          type=str, default="",
+                          help="Log file path when --log-dest is 'file' (default: script_dir/ham2mon.log)")
 
         parser.add_argument("--file-metadata", type=str,
                           dest="file_metadata", default="",
@@ -321,7 +331,9 @@ class CLParser(object):
         if voice or data or skip:
             self.record = True
 
-        self.debug = bool(options.debug)
+        self.log_level = options.log_level
+        self.log_dest = options.log_dest
+        self.log_file = options.log_file
 
         self.file_metadata: list[str] = []
         if options.file_metadata:
@@ -375,7 +387,9 @@ def main():
     print("auto_priority:       " + str(parser.auto_priority))
     print("disable_lockout:     " + str(parser.frequency_configuration.disable_lockout))
     print("disable_priority:    " + str(parser.frequency_configuration.disable_priority))
-    print("debug:               " + str(parser.debug))
+    print("log_level:           " + str(parser.log_level))
+    print("log_dest:            " + str(parser.log_dest))
+    print("log_file:            " + str(parser.log_file))
 
 if __name__ == '__main__':
     try:

--- a/apps/ham2mon.py
+++ b/apps/ham2mon.py
@@ -13,6 +13,7 @@ import h2m_parser as h2m_parser
 import asyncio
 import errors as err
 import logging
+import logging.handlers
 import traceback
 #from pathlib import Path
 from os.path import realpath, dirname
@@ -208,17 +209,43 @@ if __name__ == '__main__':
         # Do this since curses wrapper won't let parser write to screen
         PARSER = h2m_parser.CLParser()
 
-        if PARSER.debug:
-            dir = realpath(dirname(__file__))
-            logging.basicConfig(filename='%s/ham2mon.log'%(dir), \
-            level=logging.DEBUG, format='%(asctime)s %(message)s')
+        if PARSER.log_dest != 'none':
+            log_level_map = {
+                'debug': logging.DEBUG,
+                'info': logging.INFO,
+                'warn': logging.WARNING,
+                'error': logging.ERROR
+            }
+            level = log_level_map.get(PARSER.log_level, logging.WARNING)
+
+            logger = logging.getLogger()
+            logger.setLevel(level)
+
+            formatter = logging.Formatter('%(asctime)s %(message)s')
+
+            if PARSER.log_dest == 'syslog':
+                syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+                syslog_handler.setFormatter(logging.Formatter('ham2mon[%(process)d]: %(message)s'))
+                logger.addHandler(syslog_handler)
+            elif PARSER.log_dest == 'stderr':
+                stream_handler = logging.StreamHandler()
+                stream_handler.setFormatter(formatter)
+                logger.addHandler(stream_handler)
+            elif PARSER.log_dest == 'file':
+                log_file_path = PARSER.log_file
+                if not log_file_path:
+                    script_dir = realpath(dirname(__file__))
+                    log_file_path = '%s/ham2mon.log' % (script_dir)
+                file_handler = logging.FileHandler(log_file_path, delay=True)
+                file_handler.setFormatter(formatter)
+                logger.addHandler(file_handler)
 
         wrapper(main)
     except KeyboardInterrupt:
         pass
     except RuntimeError as error:
         print("")
-        print("RuntimeError: SDR hardware not detected or insufficient USB permissions. Try running as root or with --debug option.")
+        print("RuntimeError: SDR hardware not detected or insufficient USB permissions. Try running as root or with --log-level=debug option.")
         print("")
         print(f'RuntimeError: {error=}, {type(error)=}')
         logging.debug(traceback.format_exc())


### PR DESCRIPTION
*Note:* This is a breaking change for those that use the `--debug` option.

The current `--debug` option will take the application's debug messages and send them to a the file `ham2mon.log`.  This PR removes that single option and splits it into options to set level, destination and file name.   See [READEME.md](https://github.com/john-/ham2mon/tree/improve-debug-option-pr#logging) for details.

If you want to reproduce the previous `--debug` option you can do so with `--log-level debug --log-dest file`.