### PR TITLE
Classifier supports LiteRT and cleanup dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,22 @@ This application uses the [uv](https://github.com/astral-sh/uv) package manager 
     ```
 
 4. **Install and Sync Python Dependencies:**
-   Install remaining Python-only dependencies (like `numpy`, `PyYAML`, and `requests`) defined in [pyproject.toml](file:///library/pub/dev/ham2mon/pyproject.toml):
+   Install remaining Python-only dependencies (like `PyYAML`, and `requests`) defined in [pyproject.toml](file:///library/pub/dev/ham2mon/pyproject.toml):
 
     ```bash
     uv sync
     ```
 
-    _(To use the optional audio classification features, install with the tensorflow extra: `uv sync --extra tensorflow`)_
+    _(To use the optional audio classification features, you must install an interpreter runtime. The preferred order is:)_
+
+    * **LiteRT (Recommended):** The modern, lightweight runtime (~17MB). It starts up instantly and has minimal overhead:
+      ```bash
+      uv sync --extra ai-edge-litert
+      ```
+    * **TensorFlow:** The legacy heavyweight runtime (~500MB+). It has a much longer startup/import time:
+      ```bash
+      uv sync --extra tensorflow
+      ```
 
 5. **Configure Volk for Performance Optimization (Recommended):**
    GNU Radio uses the Volk (Vector Optimized Library of Kernels) library to perform accelerated SIMD calculations. You can profile your CPU to select the fastest mathematical kernels:

--- a/apps/classification_service.py
+++ b/apps/classification_service.py
@@ -1,70 +1,127 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-TensorFlow Classification Service.
-Runs as a separate subprocess to isolate TensorFlow's signal handlers and threads.
+LiteRT/TensorFlow Classification Service.
+Runs as a separate subprocess to isolate signal handlers and threads.
 """
 
-import sys
 import argparse
+import sys
+import wave
 from pathlib import Path
+
 import numpy as np
 
+# Try importing LiteRT or TFLite runtimes
 try:
-    import tensorflow as tf
-except ImportError as error:
-    print(f"tensorflow module did not load ({error})", file=sys.stderr)
-    sys.exit(1)
+    import ai_edge_litert.interpreter as litert
+
+    Interpreter = litert.Interpreter
+except ImportError:
+    try:
+        import tflite_runtime.interpreter as tflite
+
+        Interpreter = tflite.Interpreter
+    except ImportError:
+        try:
+            import tensorflow.lite as tflite
+
+            Interpreter = tflite.Interpreter
+        except ImportError:
+            print(
+                "Could not load any LiteRT/TFLite interpreter runtime. "
+                "Please install one of: 'ai-edge-litert', 'tflite-runtime', or 'tensorflow'.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
 
 class ServiceClassifier:
     def __init__(self, model_path: Path, audio_rate: int):
         self.audio_rate = audio_rate
-        self.model = tf.lite.Interpreter(model_path=model_path.absolute().as_posix())
+        self.model = Interpreter(model_path=model_path.absolute().as_posix())
         self.model.allocate_tensors()
         self.input_details = self.model.get_input_details()
         self.output_details = self.model.get_output_details()
 
-    def decode_audio(self, audio_binary):
-        audio, _ = tf.audio.decode_wav(audio_binary)
-        return tf.squeeze(audio, axis=-1)
-
     def get_spectrogram(self, file_path: str):
-        audio_binary = tf.io.read_file(file_path)
-        waveform = self.decode_audio(audio_binary)
-        total_samples = tf.size(waveform).numpy()
+        # 1. Decode WAV audio file using standard library wave module
+        with wave.open(file_path, "rb") as w:
+            nchannels, sampwidth, framerate, nframes = w.getparams()[:4]
+            data = w.readframes(nframes)
+            if sampwidth == 2:
+                audio = np.frombuffer(data, dtype=np.int16).astype(np.float32) / 32768.0
+            elif sampwidth == 1:
+                audio = (
+                    np.frombuffer(data, dtype=np.uint8).astype(np.float32) - 128.0
+                ) / 128.0
+            elif sampwidth == 4:
+                audio = (
+                    np.frombuffer(data, dtype=np.int32).astype(np.float32)
+                    / 2147483648.0
+                )
+            else:
+                raise ValueError(f"Unsupported sample width: {sampwidth}")
 
+            if nchannels > 1:
+                audio = audio.reshape(-1, nchannels)[:, 0]
+
+        # 2. Extract the target 2-second clip from the middle of the audio
+        total_samples = len(audio)
         target_samples = self.audio_rate * 2  # 2 second clip
         middle = total_samples / 2
         start = int(middle - target_samples / 2)
         if start < 0:
             start = 0
         end = int(middle + target_samples / 2)
-        waveform = waveform[start:end]
+        waveform = audio[start:end]
 
-        zero_padding = tf.zeros([target_samples] - tf.shape(waveform), dtype=tf.float32)
-        waveform = tf.cast(waveform, tf.float32)
-        equal_length = tf.concat([waveform, zero_padding], 0)
+        # 3. Apply zero padding if needed
+        if len(waveform) < target_samples:
+            pad_width = target_samples - len(waveform)
+            waveform = np.pad(waveform, (0, pad_width), "constant")
 
-        spectrogram = tf.signal.stft(equal_length, frame_length=255, frame_step=128)
-        spectrogram = tf.abs(spectrogram)
+        # 4. Compute STFT (Short-Time Fourier Transform) matching TF's behavior.
+        # tf.signal.stft's default window_fn is a periodic Hann window of length M.
+        # We mirror TF's parity-dependent raised_cosine_window quirk (where periodic
+        # and symmetric coincide for odd window lengths) to remain compatible if
+        # M is ever changed to an even number in the future.
+        M = 255
+        even = 1 - (M % 2)
+        n = M + even - 1
+        window = 0.5 - 0.5 * np.cos(2 * np.pi * np.arange(M) / n)
 
-        spectro = [spectrogram.numpy()]
-        spectro = np.expand_dims(spectro, axis=-1)
+        hop_length = 128
+        num_frames = (len(waveform) - M) // hop_length + 1
+        frames = []
+        for i in range(num_frames):
+            start_idx = i * hop_length
+            frame = waveform[start_idx : start_idx + M]
+            windowed_frame = frame * window
+            # 256-point RFFT returns 129 bins
+            rfft_out = np.fft.rfft(windowed_frame, n=256)
+            frames.append(np.abs(rfft_out))
+
+        spectrogram = np.array(frames, dtype=np.float32)
+        spectro = np.expand_dims([spectrogram], axis=-1)
         return spectro
 
     def predict(self, spectrogram):
         if spectrogram is None:
             return None
-        self.model.set_tensor(self.input_details[0]['index'], spectrogram)
+        self.model.set_tensor(self.input_details[0]["index"], spectrogram)
         self.model.invoke()
-        prediction = self.model.get_tensor(self.output_details[0]['index'])
-        types = ('V', 'D', 'S')
+        prediction = self.model.get_tensor(self.output_details[0]["index"])
+        types = ("V", "D", "S")
         return types[np.argmax(prediction[0])]
+
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True, help="Path to model")
-    parser.add_argument("--audio_rate", type=int, required=True, help="Audio sample rate")
+    parser.add_argument(
+        "--audio_rate", type=int, required=True, help="Audio sample rate"
+    )
     args = parser.parse_args()
 
     try:
@@ -93,7 +150,7 @@ def main():
             except Exception as pe:
                 print(f"Prediction error for file '{file_path}': {pe}", file=sys.stderr)
                 sys.stderr.flush()
-                result = "S" # default fallback to Skip if prediction fails
+                result = "S"  # default fallback to Skip if prediction fails
 
             sys.stdout.write(f"{result}\n")
             sys.stdout.flush()
@@ -101,6 +158,7 @@ def main():
             break
         except Exception:
             break
+
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 tensorflow = [
     "tensorflow>=2.10",
 ]
+"ai-edge-litert" = [
+    "ai-edge-litert>=1.0.0",
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,42 @@ wheels = [
 ]
 
 [[package]]
+name = "ai-edge-litert"
+version = "2.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-strenum" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "protobuf" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/f3/348482b341c92733d10fab18b9dfff80a51009f955b5e5e28639fa77b7c9/ai_edge_litert-2.1.5-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:c1d558d801ec783fa29730f87c73c66ee609e66b556b83675f81c5be72bf4167", size = 9708688, upload-time = "2026-05-15T23:34:12.942Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a5/f4d3bf26fe7d596d14230114c0da1f0b8f9ccfe4baeeeb4c1f5caaeabd4f/ai_edge_litert-2.1.5-cp310-cp310-manylinux_2_27_aarch64.whl", hash = "sha256:06b9c2ea2a6c9c54a0f1f14825e26511c75ddfc140da81f264151d94bea0c845", size = 12864390, upload-time = "2026-05-15T23:11:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ce/e48f602f2c9ad380faf99d15f4a1d7c563a43980725bb5d6f0badff8f4a1/ai_edge_litert-2.1.5-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:90af4d726e34458f50f01118fe7bf8a6b223a820e6981c9d741f08d8f8489706", size = 17564222, upload-time = "2026-05-15T23:05:28.906Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/19/3225b96e713b2e874c18bbedd982725704c89f224ea722c0802df23f320d/ai_edge_litert-2.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:9e70304490274992be0a03b29faf819f76dc7dd2754a3ddcfed25e689dab150c", size = 17752338, upload-time = "2026-05-15T23:39:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/7f/ec543ef2f79cf5b5909521cb614162ec1e6fc9df863ccae23142260dd8c7/ai_edge_litert-2.1.5-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:cf9a6e98677d26fd900ec9459a19cf5cce9f94c64132d728485eeb9accd5c162", size = 9709620, upload-time = "2026-05-15T23:34:15.065Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/84/a1ec0a9c6c345e79207b2a3a2a8e1e9572f412143100dc650f332c53d84f/ai_edge_litert-2.1.5-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:1edf83d132919b0b95bb5ded64e79bfed018168d3584c28fa30a8eb0d3bfca6b", size = 12866358, upload-time = "2026-05-15T23:11:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/44/3c365bc63b744316ef61c75761e53f34f9cdc0ba31fddc1d1039ca5322b4/ai_edge_litert-2.1.5-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:7c54e45589831fbaeec1481df530e336d0112002a6193bc28f7aafa5f4898a3a", size = 17566472, upload-time = "2026-05-15T23:05:31.285Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/47/d3956aeddc00194463dcc83991ad58759b1a94672d66e7b7c5d2be1d95de/ai_edge_litert-2.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:ad7844c7c2431dfe36debf6d4541f27af198848ed3090cbaacbdf2bb2cd377c7", size = 17753382, upload-time = "2026-05-15T23:39:22.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/37/cf525a4ed6aff573b10a162b7bff19673e50ce6f45daac0a095dcd099a28/ai_edge_litert-2.1.5-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b62fd3d90e643bcc3e3a31885a7636b5662527d48c27154cf07793f26896f018", size = 9711976, upload-time = "2026-05-15T23:34:16.988Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/6f/b43fc56831ecc439a6e6eb0e1bfdffbfe6213e8c706aa421017dce1ac56b/ai_edge_litert-2.1.5-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:1d282722cdfb70bb42d457f4bfe7789f88187ccadd73fea9f0107dce6e98fe45", size = 12867617, upload-time = "2026-05-15T23:11:22.759Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/20/a76ba29b1c4c3009b5c64f4ec7f5fe5165104fe15481bd79b55927948541/ai_edge_litert-2.1.5-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:f1c6d8db4382890881baeb8ed13c0802ada022e0b104b0db8fccf31353899ee0", size = 17570644, upload-time = "2026-05-15T23:05:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fa/5399085daffd9949668d13a83a48db9f69af535ef9f9d06fdf71f0205321/ai_edge_litert-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:6d2db6759188b12be9fd095468c3c7069c1bc7c128de78f42f862fb654d247ea", size = 17755006, upload-time = "2026-05-15T23:39:24.555Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fd/28f24305904954f31ee1a979eea39b670c6a1ab13cf6e5e4fe5f128e9eff/ai_edge_litert-2.1.5-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:2af16685a4cc8923d9a89ee5c732b8c66ae2c4d0cb538dbcebba3b93afb662ca", size = 9713185, upload-time = "2026-05-15T23:34:19.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/88/e7e32b37f972b4877df788d1ad0995388f823d74dc2743b200bf71a25a53/ai_edge_litert-2.1.5-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:57506e9e9b91ee04e4cf3e986d184b0c92f1aa9f510c32841835c0d719a7fbb5", size = 12867247, upload-time = "2026-05-15T23:11:24.667Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c1/5192c360a467dd6e09fa28388022c37bca5d9777e616da40dc5d517186a9/ai_edge_litert-2.1.5-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:b7825e13454a90e7a4782ecdb6f6d987a2bcc9147aa90eb181193867bf696f24", size = 17570488, upload-time = "2026-05-15T23:05:36.078Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ba/154599984a8eccbdd14bcd89fabc2e9cbdfcbf537a3c1ab08712c7ce7d02/ai_edge_litert-2.1.5-cp313-cp313-win_amd64.whl", hash = "sha256:602fc90f6baf396df0fe4b0317b35627305c2233beb48db194b79e7e420bafa7", size = 17755085, upload-time = "2026-05-15T23:39:26.901Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/51/34f0ad0def8b15093d602ca6904b129d3ab242ae4711c872190d5c95c010/ai_edge_litert-2.1.5-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:597ea79f947452c79ca7e9dd7abfedad6179302851df4a4bb4c755069a2f5ffe", size = 9712496, upload-time = "2026-05-15T23:34:21.36Z" },
+    { url = "https://files.pythonhosted.org/packages/42/43/2b8ef317dca3096372cbf820aa5a3a6c8857dad67f31840a1e17a951e2d3/ai_edge_litert-2.1.5-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:41d2e8267f047ed14f14a5ff4e0f677a9c5143dd17a36991513f8cc5ef580a3b", size = 12867899, upload-time = "2026-05-15T23:11:26.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d5/9640952de755409c84e09eec5d107675c59fe4f4859391464275eb2c3db6/ai_edge_litert-2.1.5-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:4fa10d99b2f8647678850684d31075fbb304f50535d5788c2ca93e273ce727a8", size = 17570849, upload-time = "2026-05-15T23:05:37.981Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d4/0843e5a41bf71eb99ccd1e54714485df527bec19e8c8e679e1395176345d/ai_edge_litert-2.1.5-cp314-cp314-win_amd64.whl", hash = "sha256:14b35558bfce76146046cc2fc647f3fde97146e8b7622ea7fb02e85ac16cd906", size = 18380722, upload-time = "2026-05-15T23:39:29.365Z" },
+]
+
+[[package]]
 name = "astunparse"
 version = "1.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -37,6 +73,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "backports-strenum"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/c7/2ed54c32fed313591ffb21edbd48db71e68827d43a61938e5a0bc2b6ec91/backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414", size = 7257, upload-time = "2023-12-09T14:36:40.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/50/56cf20e2ee5127b603b81d5a69580a1a325083e2b921aa8f067da83927c0/backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83", size = 8304, upload-time = "2023-12-09T14:36:39.905Z" },
 ]
 
 [[package]]
@@ -419,6 +464,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+ai-edge-litert = [
+    { name = "ai-edge-litert" },
+]
 tensorflow = [
     { name = "tensorflow" },
 ]
@@ -432,11 +480,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ai-edge-litert", marker = "extra == 'ai-edge-litert'", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.25" },
     { name = "tensorflow", marker = "extra == 'tensorflow'", specifier = ">=2.10" },
 ]
-provides-extras = ["tensorflow"]
+provides-extras = ["tensorflow", "ai-edge-litert"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1150,6 +1199,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Current audio classification uses the full `tensorflow` python library.  This change allows ham2mon to use library `ai-edge-litert` as primary for classification and falls back to `tensorflow` library if that is not available.

See the [READMD.md](https://github.com/john-/ham2mon/tree/support-litert-pr#step-by-step-setup) for how to install these libraries.
