### PR TITLE
Support multiple CTCSS tones

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,10 @@ options:
                         script_dir/ham2mon.log)
   --file-metadata FILE_METADATA
                         Comma-separated list of metadata fields to include in
-                        output filenames (e.g. priority,strength)
+                        output filenames (e.g. priority,strength,ctcss)
+  --max-ctcss-tones MAX_CTCSS_TONES
+                        Maximum number of CTCSS tones configured per frequency
+                        (default: 0, disabled by default for performance reasons)
 ```
 Note: The available gains are hardware specific.  The user interface will list the gains available based on hardware option supplied to ham2mon.
 
@@ -410,7 +413,7 @@ graph TD
 
 See [receiver.py](file:///library/pub/dev/ham2mon/apps/receiver.py) for the Python coded flow.  The complex samples are grouped into a vector of length 2^n and then decimated by keeping “1 in N” vectors. The FFT is taken followed by magnitude-squared to form a power spectrum.  The FFT length is chosen, based on sample rate, to span about 3 RBW bins across a 12.5 kHz FM channel.  The spectrum vectors are then integrated and further decimated for a video average, akin to the VBW of a spectrum analyzer.  The spectrum is then probed by the Python code at ~10 Hz rate.
 
-The demodulator blocks are put into a hierarchical GR block so multiple can be instantiated in parallel.  A frequency translating FIR filter tunes the channel, followed by two more decimating FIR filters to 12.5 kHz channel bandwidth.  For sample rates 1 Msps or greater, the total decimation for the first three stages takes the rate to 40-80 ksps.  A non-blocking power squelch silences the channel, followed by quadrature (FM) demodulation, or AGC and AM demodulation.  The audio stream is filtered to 3.5 kHz bandwidth and further decimated to 8-16 ksps.  A polyphase arbitrary resampler takes the final audio rate to a constant 8 ksps (or 16 ksps for AM/WBFM). The audio stream is then routed through a parallel-path CTCSS bypass/filter chain, mixed with other streams, or routed to a selector-controlled WAV file sink/null sink path via a blocking squelch to remove dead audio.
+The demodulator blocks are put into a hierarchical GR block so multiple can be instantiated in parallel.  A frequency translating FIR filter tunes the channel, followed by two more decimating FIR filters to 12.5 kHz channel bandwidth.  For sample rates 1 Msps or greater, the total decimation for the first three stages takes the rate to 40-80 ksps.  A non-blocking power squelch silences the channel, followed by quadrature (FM) demodulation, or AGC and AM demodulation.  The audio stream is filtered to 3.5 kHz bandwidth and further decimated to 8-16 ksps.  A polyphase arbitrary resampler takes the final audio rate to a constant 8 ksps (or 16 ksps for AM/WBFM). The audio stream is then routed through a parallel-path CTCSS bypass/filter chain (consisting of a bypass branch and up to `max_ctcss_tones` parallel squelch/filter branches running in parallel, with only the active branch's gain enabled), mixed with other streams, or routed to a selector-controlled WAV file sink/null sink path via a blocking squelch to remove dead audio.
 
 The scanner.py contains the control code, and may be run on on it's own non-interactively.  It instantiates the receiver.py with N demodulators and probes the average spectrum at ~10 Hz.  The spectrum is processed with estimate.py, which takes a weighted average of the spectrum bins that are above a threshold.  This weighted average does a fair job of estimating the modulated channel center to sub-kHz resolution given the RBW is several kHz.  The estimate.py returns a list of baseband channels that are rounded to the nearest 5 kHz (for NBFM band plan ambiguity).
 
@@ -542,7 +545,7 @@ No capability is provided to train the model.  Training data will not be provide
 
 ## Filename Metadata
 
-When writing transmissions to disk (using `-w` or audio classification options), you can customize the output filenames to include optional metadata by specifying the `--file-metadata` option. This option accepts a comma-separated list of metadata fields to include (e.g. `--file-metadata priority,strength`).
+When writing transmissions to disk (using `-w` or audio classification options), you can customize the output filenames to include optional metadata by specifying the `--file-metadata` option. This option accepts a comma-separated list of metadata fields to include (e.g. `--file-metadata priority,strength,ctcss`).
 
 Supported metadata fields:
 
@@ -551,14 +554,15 @@ Supported metadata fields:
   - Automatic priorities (dynamically added from auto-priority) are formatted as `PA`.
 - `strength`: Appends the average signal strength (mean RSSI) recorded during the active transmission in dB (e.g., `-48dB`).
   - Note: The raw FFT spectrum power values are automatically calibrated to a standard negative RSSI range (applying a `-70 dB` calibration offset) to align with standard receiver squelch scales.
+- `ctcss`: Appends the matched CTCSS tone frequency formatted with a single decimal point followed by `Hz` (e.g., `100.0Hz`).
 
 > [!NOTE]
-> If a requested metadata field is unavailable when the recording is persisted (e.g., if a channel's priority is not configured, or if signal strength data is `None` because the channel was stopped before any signal power stats could be accumulated), the corresponding segment is completely omitted from the output filename. No placeholders are used.
+> If a requested metadata field is unavailable when the recording is persisted (e.g., if a channel's priority is not configured, or if signal strength data is `None` because the channel was stopped before any signal power stats could be accumulated, or if the transmission had no matching CTCSS tone), the corresponding segment is completely omitted from the output filename. No placeholders are used.
 
 ### Filename Format
 
 The metadata fields are appended in a structured sequence using underscores (`_`) as delimiters:
-`<frequency>[_classification][_priority][_strength]_<timestamp>.wav`
+`<frequency>[_classification][_priority][_strength][_ctcssHz]_<timestamp>.wav`
 
 Examples:
 
@@ -566,10 +570,11 @@ Examples:
 - With priority requested: `460.1250_P1_20231102_140010.123.wav`
 - With priority and strength requested: `460.1250_P1_-48dB_20231102_140010.123.wav`
 - With auto-priority and strength requested: `460.1250_PA_-45dB_20231102_140010.123.wav`
+- With priority, strength, and ctcss requested: `460.1250_P1_-48dB_100.0Hz_20231102_140010.123.wav`
 - With strength requested but unavailable (e.g. no signal stats): `460.1250_20231102_140010.123.wav`
 
 If audio classification is enabled (e.g., via `--voice`, which adds a classification segment such as `V` or `D`), it will be inserted directly after the frequency:
-- With classification, priority, and strength: `460.1250_V_P1_-48dB_20231102_140010.123.wav`
+- With classification, priority, strength, and CTCSS: `460.1250_V_P1_-48dB_100.0Hz_20231102_140010.123.wav`
 
 ## CTCSS Squelch and Tone Filtering
 
@@ -586,6 +591,22 @@ frequencies:
     ctcss: 100.0   # Configured expected CTCSS tone in Hz
 ```
 
+To support **multiple valid CTCSS tones** on a single frequency or frequency range, declare the frequency block multiple times, changing only the `ctcss` tone frequency. These will merge into a single tuner entry at load time:
+
+```yaml
+frequencies:
+  # Primary tone
+  - label: "CTCSS Test Channel"
+    single: 144.500
+    ctcss: 100.0
+  # Backup tone
+  - label: "CTCSS Test Channel"
+    single: 144.500
+    ctcss: 141.3
+```
+
+By default, **CTCSS demodulation is disabled (`--max-ctcss-tones` defaults to 0) for performance reasons**, as running CTCSS tone detection blocks on every channel incurs significant CPU overhead even when no signal is present. To enable CTCSS tone detection, you must specify a limit (e.g. `--max-ctcss-tones 3`). Any configured tones loaded beyond this limit are validated and rejected at configuration load time.
+
 ### User Options
 
 Depending on your configuration in `frequencies.yaml` (specified via the `-F`/`--frequencies` option), the application operates in one of two modes:
@@ -595,11 +616,11 @@ Depending on your configuration in `frequencies.yaml` (specified via the `-F`/`-
    * **Behavior:** The receiver will record and unmute any signal that is strong enough to break the RF carrier power squelch, regardless of whether a sub-audible tone is present or what its frequency is. Additionally, the 300Hz high-pass filter is dynamically bypassed in this mode to preserve full audio fidelity and bass (e.g. for broadcast FM music).
 2. **Tone Squelch (CTCSS) Mode:**
    * **Trigger:** Enabled for channels configured **with** a specific `ctcss` key (e.g. `ctcss: 100.0`).
-   * **Behavior:** The receiver will only unmute and keep the recording if the signal contains the specified CTCSS tone. Transmissions carrying a different tone or no tone at all are muted and discarded.
+   * **Behavior:** The receiver will only unmute and keep the recording if the signal contains one of the configured CTCSS tones. Transmissions carrying a different tone or no tone at all are muted and discarded.
 
 ### GUI Display
 
-When a tuned frequency is configured with a CTCSS tone (Tone Squelch Mode), the active CTCSS tone frequency (e.g. `100.0` Hz) will be displayed at the end of the channel list row in the **CHANNELS** window, provided the window width is at least 22 characters.
+When a tuned frequency is configured with a CTCSS tone (Tone Squelch Mode), the matched CTCSS tone frequency (e.g. `100.0` Hz) will be displayed in bold/italics at the end of the channel list row in the **CHANNELS** window. Before a tone is matched (such as during the initial grace period before Goertzel detection completes), it falls back to displaying the primary configured tone. (Completely idle channels drop out of the list display entirely.) This is rendered provided the window width is at least 22 characters.
 
 ### Technical Implementation
 

--- a/apps/channel_loggers.py
+++ b/apps/channel_loggers.py
@@ -136,6 +136,7 @@ class FixedField(ChannelLogger):
             text = (f'{now.strftime("%Y-%m-%d, %H:%M:%S.%f")}: {msg.state:<4}{msg.rf:<10}'
                     f'{msg.channel:<2}{msg.priority if msg.priority else "":<2}'
                     f'{msg.classification if msg.classification else "":<2}'
+                    f'{f"{msg.matched_ctcss:.1f}" if msg.matched_ctcss else "":<7}'
                     f'{msg.file if msg.file else "":<50}\n'
                     )
             file.write(text)

--- a/apps/cursesgui.py
+++ b/apps/cursesgui.py
@@ -319,7 +319,6 @@ class ChannelWindow(object):
                 freq_str = freq_str[:-1] + ' '
 
             icon = 'P' if channel.priority else ' '
-            label = channel.label or ''
 
             attributes = (self.attrs['bold_freq'], self.attrs['bold_icon']) if channel.active else (
                 self.attrs['normal_freq'], self.attrs['normal_icon'])
@@ -330,10 +329,22 @@ class ChannelWindow(object):
 
             label_start = 14
 
-            has_ctcss = getattr(channel, 'ctcss', None) is not None
+            matched_ctcss = getattr(channel, 'matched_ctcss', None)
+            primary_ctcss = channel.ctcss or (channel.ctcss_tones[0] if channel.ctcss_tones else None)
 
-            if has_ctcss:
-                ctcss_str = f'{channel.ctcss:>5.1f}'
+            has_multiple_ctcss = len(channel.ctcss_tones) > 1
+            is_testing_ctcss = channel.active and not channel.hanging and has_multiple_ctcss and matched_ctcss is None
+
+            if is_testing_ctcss:
+                label = f"{channel.rf:.4f}..."
+                display_ctcss = None
+            else:
+                label = channel.label or ''
+                display_ctcss = matched_ctcss if matched_ctcss is not None else primary_ctcss
+
+
+            if display_ctcss is not None:
+                ctcss_str = f'{display_ctcss:>5.1f}'
                 win.addnstr(row, col + self.width - 5, ctcss_str , 5, attributes[1] | curses.A_ITALIC)
                 win.addnstr(row, col + self.width - 6, ' ', 1, attributes[0])
                 label_end = self.width - 6

--- a/apps/demodulators/AM.py
+++ b/apps/demodulators/AM.py
@@ -59,7 +59,8 @@ class TunerDemodAM(BaseTuner):
                  notify_scanner: Callable,
                  file_metadata: list[str] | None = None,
                  get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None,
-                 get_ctcss_info: Callable[[int], float | None] | None = None,
+                 get_ctcss_info: Callable[[float], list[float]] | None = None,
+                 max_ctcss_tones: int = 0,
                  wav_dir: str = "wav"):
         gr.hier_block2.__init__(self, "TunerDemodAM",
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex),
@@ -67,7 +68,7 @@ class TunerDemodAM(BaseTuner):
 
         super().__init__(classify, notify_scanner, file_metadata=file_metadata,
                          get_priority_info=get_priority_info, get_ctcss_info=get_ctcss_info,
-                         wav_dir=wav_dir, audio_rate=audio_rate)
+                         wav_dir=wav_dir, audio_rate=audio_rate, max_ctcss_tones=max_ctcss_tones)
 
         # Default values
         self.center_freq = 0

--- a/apps/demodulators/BaseTuner.py
+++ b/apps/demodulators/BaseTuner.py
@@ -27,18 +27,17 @@ class BaseTuner(gr.hier_block2):
     See TunerDemodNBFM and TunerDemodAM for better documentation.
     """
 
-    _CTCSS_GRACE_PERIOD_S: float = 0.4  # Seconds to allow CTCSS detector to stabilise before flagging a mismatch
-    _MAX_CTCSS_TONES: int = 3  # Cap on simultaneous CTCSS tones checked per channel. Not used yet
-                                # (squelch still checks a single tone) -- reserved for the
-                                # multi-tone detector work in frequency_manager.get_ctcss_tones().
+    _CTCSS_GRACE_PERIOD_S: float = 0.7  # Seconds to allow CTCSS detector to stabilise before flagging a mismatch
+    _CTCSS_DETECTOR_LEN: int = 4000  # Goertzel block size (number of samples) for CTCSS detection
     _channel_lock = threading.Lock()
     _channel_counter: int = 0  # incremented for each new demodulator
 
     def __init__(self, classify: Classifier | None, notify_scanner: Callable,
                  file_metadata: list[str] | None = None,
                  get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None,
-                 get_ctcss_info: Callable[[int], float | None] | None = None,
-                 wav_dir: str = "wav", audio_rate: int = 8000) -> None:
+                 get_ctcss_info: Callable[[float], list[float]] | None = None,
+                 wav_dir: str = "wav", audio_rate: int = 8000,
+                 max_ctcss_tones: int = 0) -> None:
         with BaseTuner._channel_lock:
             BaseTuner._channel_counter += 1
             self.channel = BaseTuner._channel_counter
@@ -52,18 +51,21 @@ class BaseTuner(gr.hier_block2):
 
         self.file_metadata: list[str] = file_metadata if file_metadata is not None else []
         self.get_priority_info = get_priority_info
+        # NOTE: kept the name `get_ctcss_info` (rather than renaming to
+        # get_ctcss_tones) to avoid cascading the rename through receiver.py,
+        # the NBFM/AM/WBFM subclasses, and all their test fixtures. The
+        # contract has changed though: this now returns a list of valid
+        # tones (possibly empty), not a single tone.
         self.get_ctcss_info = get_ctcss_info
         self.wav_dir = wav_dir
         self.audio_rate = audio_rate
         self.ctcss_level = 0.0001
-
-        # CTCSS squelch — gate=False so it outputs zeros instead of gating when
-        # tone is absent. This keeps samples flowing through the HPF and prevents
-        # history buffer freezing, while still muting the audio.
-        self.analog_ctcss_squelch_ff = analog.ctcss_squelch_ff(self.audio_rate, 100.0, self.ctcss_level, 1000, 0, False)
+        self.max_ctcss_tones = max_ctcss_tones
+        self.matched_ctcss_tone: float | None = None
+        self._active_tones: list[float] = []
 
         # Pre-calculate CTCSS high-pass filter taps (strips the sub-audible tone from
-        # recorded audio when CTCSS is active; taps swapped to all-pass when not).
+        # recorded/played audio when CTCSS is active; taps swapped to all-pass when not).
         self.ctcss_hp_taps = grfilter.firdes.high_pass(
             1,
             self.audio_rate,
@@ -71,37 +73,49 @@ class BaseTuner(gr.hier_block2):
             10.0,
             window.WIN_HAMMING
         )
-        self.high_pass_filter_ctcss = grfilter.fir_filter_fff(1, [1.0])
 
-        # Signal path topology (parallel bypass and CTCSS paths with adder):
+        # Signal path topology (parallel bypass and up to max_ctcss_tones CTCSS
+        # chains, all summed by an adder):
         #
-        #                   ┌──► bypass_gain ─────────────────────────┐
-        #   self.ctcss_in ──┤                                         ├──► adder ──► hub ──► output
-        #                   └──► ctcss_squelch ──► HPF ──► ctcss_gain ┘
+        #                   ┌──► bypass_gain ───────────────────────────────────┐
+        #   self.ctcss_in ──┼──► ctcss_squelch[0] ──► HPF[0] ──► ctcss_gain[0] ──┤
+        #                   ├──► ctcss_squelch[1] ──► HPF[1] ──► ctcss_gain[1] ──┼──► adder ──► hub ──► output
+        #                   └──► ctcss_squelch[2] ──► HPF[2] ──► ctcss_gain[2] ──┘
         #
-        # Both paths remain connected and active. The routing is controlled by
-        # gain parameters on the bypass_gain and ctcss_gain blocks:
-        #   bypass_gain=1.0 / ctcss_gain=0.0 → bypass path (CTCSS disabled)
-        #   bypass_gain=0.0 / ctcss_gain=1.0 → CTCSS chain (CTCSS enabled)
-        # Because samples continuously flow through Path 1 even when bypass mode
-        # is selected, the HPF history buffers are never frozen and do not leak
-        # previous transmissions when switching back to CTCSS.
+        # All paths remain connected and active at all times (samples always flow
+        # through every chain), so HPF history buffers are never frozen and don't
+        # leak previous transmissions when a chain (re)activates. Routing is
+        # controlled purely by the gain blocks:
+        #   bypass_gain=1.0 / all ctcss_gain=0.0        → bypass path (CTCSS disabled)
+        #   bypass_gain=0.0 / ctcss_gain[i]=1.0 for i<N  → CTCSS chains 0..N-1 active
+        # Each squelch is built with gate=False, so a chain whose tone isn't
+        # currently present outputs zeros rather than gating -- since at most one
+        # configured tone can be present in a real transmission, only that chain
+        # contributes non-zero samples to the sum, with no need to pick a "winning"
+        # tone in software. A channel with 0 or 1 configured tones behaves exactly
+        # as it did before this was generalized to N tones.
 
         self.ctcss_in = blocks.multiply_const_ff(1.0)
         self._bypass_gain = blocks.multiply_const_ff(1.0)
-        self._ctcss_gain = blocks.multiply_const_ff(0.0)
         self._ctcss_adder = blocks.add_ff()
         self._ctcss_hub = blocks.multiply_const_ff(1.0)   # fan-out hub for ctcss_out
 
         # Wire bypass path: input → bypass_gain → adder port 0.
         self.connect(self.ctcss_in, self._bypass_gain, (self._ctcss_adder, 0))
 
-        # Wire CTCSS chain: input → ctcss_squelch → hpf → ctcss_gain → adder port 1.
-        self.connect(self.ctcss_in,
-                     self.analog_ctcss_squelch_ff,
-                     self.high_pass_filter_ctcss,
-                     self._ctcss_gain,
-                     (self._ctcss_adder, 1))
+        # Wire one CTCSS chain per tone slot: input → squelch[i] → hpf[i] → gain[i] → adder port i+1.
+        self._ctcss_squelches: list = []
+        self._ctcss_hpfs: list = []
+        self._ctcss_gains: list = []
+        for i in range(self.max_ctcss_tones):
+            # gate=False — see topology note above.
+            squelch = analog.ctcss_squelch_ff(self.audio_rate, 100.0, self.ctcss_level, self._CTCSS_DETECTOR_LEN, 0, False)
+            hpf = grfilter.fir_filter_fff(1, [1.0])
+            gain = blocks.multiply_const_ff(0.0)
+            self.connect(self.ctcss_in, squelch, hpf, gain, (self._ctcss_adder, i + 1))
+            self._ctcss_squelches.append(squelch)
+            self._ctcss_hpfs.append(hpf)
+            self._ctcss_gains.append(gain)
 
         # Wire adder output into hub so subclasses can fan out to multiple consumers.
         self.connect(self._ctcss_adder, self._ctcss_hub)
@@ -109,6 +123,7 @@ class BaseTuner(gr.hier_block2):
         self.ctcss_out = self._ctcss_hub      # subclasses: ctcss_out → sink/hier-output
 
         self._ctcss_enabled = False
+        self._active_tone_count = 0   # how many of the N chains are configured/active for the current channel
         self.ctcss_matched = False
         self.ctcss_checked = False
         self._ctcss_start_time = 0.0
@@ -162,13 +177,13 @@ class BaseTuner(gr.hier_block2):
         self.center_freq = center_freq
         self.freq_xlating_fir_filter_ccc.set_center_freq(self.center_freq)
 
-        # Dynamically configure CTCSS squelch tone and routing
-        ctcss_tone = None
+        # Dynamically configure CTCSS squelch tones and routing
+        ctcss_tones: list[float] = []
         if self.center_freq != 0 and self.get_ctcss_info is not None:
             rf_freq = baseband_to_frequency(self.center_freq, rf_center_freq)
-            ctcss_tone = self.get_ctcss_info(rf_freq)
+            ctcss_tones = self.get_ctcss_info(rf_freq) or []
 
-        self._apply_ctcss_config(ctcss_tone)
+        self._apply_ctcss_config(ctcss_tones)
 
         # Set the file name if recording
         if self.center_freq == 0 or not self.record:
@@ -231,7 +246,8 @@ class BaseTuner(gr.hier_block2):
                                 rf=baseband_to_frequency(self.center_freq, rf_center_freq),
                                 bb=self.center_freq,
                                 channel=self.channel,
-                                signal_db=avg_signal)
+                                signal_db=avg_signal,
+                                matched_ctcss=self.matched_ctcss_tone)
 
         # Discard the file if flagged as mismatched CTCSS
         if self.discard_current:
@@ -276,6 +292,8 @@ class BaseTuner(gr.hier_block2):
                 name_parts.append("PA" if is_auto else f"P{priority}")
         if 'strength' in self.file_metadata and avg_signal is not None:
             name_parts.append(f"{avg_signal}dB")
+        if 'ctcss' in self.file_metadata and self.matched_ctcss_tone is not None:
+            name_parts.append(f"{self.matched_ctcss_tone:.1f}Hz")
         name_parts.append(self.tstamp_str)
 
         new_name = f'{self.wav_dir}/{"_".join(name_parts)}.wav'
@@ -291,16 +309,18 @@ class BaseTuner(gr.hier_block2):
         """
         self.analog_pwr_squelch_cc.set_threshold(squelch_db)
 
-    def set_ctcss_tone(self, ctcss_tone: float) -> None:
-        """Sets the CTCSS tone frequency on the CTCSS squelch block.
+    def _set_ctcss_tone(self, index: int, ctcss_tone: float) -> None:
+        """Sets the CTCSS tone frequency on chain `index`'s squelch block.
 
-        This is a public API for setting CTCSS squelch parameters.
+        This is the internal per-slot equivalent of the old (single-tone)
+        public `set_ctcss_tone`. Not exposed publicly since nothing outside
+        this class calls it.
         """
-        self.ctcss_tone = ctcss_tone
-        self.analog_ctcss_squelch_ff.set_frequency(ctcss_tone)
+        self._ctcss_squelches[index].set_frequency(ctcss_tone)
 
     def is_ctcss_mismatched(self) -> bool:
-        """Returns True if there is an active signal (RF squelch open) but CTCSS tone does not match (CTCSS squelch closed)."""
+        """Returns True if there is an active signal (RF squelch open) but none of the
+        channel's configured CTCSS tones currently match (all their squelches closed)."""
         if not self._ctcss_enabled:
             return False
 
@@ -310,17 +330,25 @@ class BaseTuner(gr.hier_block2):
         if self.ctcss_matched:
             return False
 
-        # Check if demodulator RF squelch is open and CTCSS squelch is open
+        # Check if demodulator RF squelch is open and at least one active CTCSS
+        # chain's squelch is open (i.e. its specific tone is present)
         rf_open = self.analog_pwr_squelch_cc.unmuted()
-        ctcss_open = self.analog_ctcss_squelch_ff.unmuted()
+        matched_idx = None
+        if rf_open:
+            for i in range(self._active_tone_count):
+                if self._ctcss_squelches[i].unmuted():
+                    matched_idx = i
+                    break
 
         # Update matching status
-        if rf_open and ctcss_open:
+        if matched_idx is not None:
             self.ctcss_matched = True
+            if matched_idx < len(self._active_tones):
+                self.matched_ctcss_tone = self._active_tones[matched_idx]
 
         # If we haven't matched yet, check if we've exceeded the grace period
         if not self.ctcss_matched:
-            # Give the CTCSS block 0.4 seconds to detect the tone and stabilize
+            # Give the CTCSS chains 0.4 seconds to detect the tone and stabilize
             if time.time() - self._ctcss_start_time < self._CTCSS_GRACE_PERIOD_S:
                 return False
             # If 0.4s passed and still not matched while RF is open, it's a mismatch
@@ -337,10 +365,12 @@ class BaseTuner(gr.hier_block2):
         self._is_started = True
         if self._ctcss_enabled:
             self._bypass_gain.set_k(0.0)
-            self._ctcss_gain.set_k(1.0)
+            for i, gain in enumerate(self._ctcss_gains):
+                gain.set_k(1.0 if i < self._active_tone_count else 0.0)
         else:
             self._bypass_gain.set_k(1.0)
-            self._ctcss_gain.set_k(0.0)
+            for gain in self._ctcss_gains:
+                gain.set_k(0.0)
 
         if hasattr(self, '_rec_selector'):
             try:
@@ -348,24 +378,52 @@ class BaseTuner(gr.hier_block2):
             except IndexError as e:
                 logging.warning("Failed to configure recording selector: %s", e)
 
-    def _apply_ctcss_config(self, ctcss_tone: float | None) -> None:
-        """Applies CTCSS configuration parameters and updates routing if started."""
-        if ctcss_tone is not None:
+    def _apply_ctcss_config(self, ctcss_tones: list[float] | None) -> None:
+        """Applies CTCSS configuration parameters and updates routing if started.
+
+        Args:
+            ctcss_tones: Valid CTCSS tones for the channel at the currently tuned
+                frequency. Empty/None means CTCSS is not configured for this
+                channel. At most self.max_ctcss_tones are honored; any beyond that
+                are logged and ignored.
+        """
+        tones = list(ctcss_tones) if ctcss_tones else []
+
+        if len(tones) > self.max_ctcss_tones:
+            logging.warning(
+                f"Channel {self.channel}: {len(tones)} CTCSS tones configured but "
+                f"only {self.max_ctcss_tones} are supported; the rest will be ignored")
+            tones = tones[:self.max_ctcss_tones]
+
+        self._active_tone_count = len(tones)
+        self._active_tones = tones
+        self.matched_ctcss_tone = None
+
+        if tones:
             self._ctcss_enabled = True
             self._ctcss_start_time = time.time()  # Start grace period timer
             self.ctcss_matched = False
             self.ctcss_checked = False
-            self.set_ctcss_tone(ctcss_tone)
-            self.analog_ctcss_squelch_ff.set_level(self.ctcss_level)
-            self.high_pass_filter_ctcss.set_taps(self.ctcss_hp_taps)
+            for i, tone in enumerate(tones):
+                self._set_ctcss_tone(i, tone)
+                self._ctcss_squelches[i].set_level(self.ctcss_level)
+                # Re-applying taps on every retune resets the HPF's history, so a
+                # newly (re)activated chain doesn't leak the previous channel's audio.
+                self._ctcss_hpfs[i].set_taps(self.ctcss_hp_taps)
+            # Any slots beyond the configured count stay/become inactive
+            for i in range(len(tones), self.max_ctcss_tones):
+                self._ctcss_hpfs[i].set_taps([1.0])
             if self._is_started:
                 self._bypass_gain.set_k(0.0)
-                self._ctcss_gain.set_k(1.0)
+                for i, gain in enumerate(self._ctcss_gains):
+                    gain.set_k(1.0 if i < len(tones) else 0.0)
         else:
             self._ctcss_enabled = False
-            # Swap taps to all-pass (1.0) when CTCSS is disabled so the HPF block
-            # acts as a simple unity gain/identity filter.
-            self.high_pass_filter_ctcss.set_taps([1.0])
+            # Swap taps to all-pass (1.0) on every chain when CTCSS is disabled so
+            # each HPF acts as a simple unity gain/identity filter.
+            for hpf in self._ctcss_hpfs:
+                hpf.set_taps([1.0])
             if self._is_started:
                 self._bypass_gain.set_k(1.0)
-                self._ctcss_gain.set_k(0.0)
+                for gain in self._ctcss_gains:
+                    gain.set_k(0.0)

--- a/apps/demodulators/NBFM.py
+++ b/apps/demodulators/NBFM.py
@@ -57,7 +57,8 @@ class TunerDemodNBFM(BaseTuner):
                  notify_scanner: Callable,
                  file_metadata: list[str] | None = None,
                  get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None,
-                 get_ctcss_info: Callable[[int], float | None] | None = None,
+                 get_ctcss_info: Callable[[float], list[float]] | None = None,
+                 max_ctcss_tones: int = 0,
                  wav_dir: str = "wav"):
         gr.hier_block2.__init__(self, "TunerDemodNBFM",
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex),
@@ -65,7 +66,7 @@ class TunerDemodNBFM(BaseTuner):
 
         super().__init__(classify, notify_scanner, file_metadata=file_metadata,
                          get_priority_info=get_priority_info, get_ctcss_info=get_ctcss_info,
-                         wav_dir=wav_dir, audio_rate=audio_rate)
+                         wav_dir=wav_dir, audio_rate=audio_rate, max_ctcss_tones=max_ctcss_tones)
 
         # Default values
         self.center_freq = 0

--- a/apps/demodulators/WBFM.py
+++ b/apps/demodulators/WBFM.py
@@ -69,7 +69,8 @@ class TunerDemodWBFM(BaseTuner):
                  notify_scanner: Callable,
                  file_metadata: list[str] | None = None,
                  get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None,
-                 get_ctcss_info: Callable[[int], float | None] | None = None,
+                 get_ctcss_info: Callable[[float], list[float]] | None = None,
+                 max_ctcss_tones: int = 0,
                  wav_dir: str = "wav"):
 
         gr.hier_block2.__init__(self, "TunerDemodWBFM",
@@ -78,7 +79,7 @@ class TunerDemodWBFM(BaseTuner):
 
         super().__init__(classify, notify_scanner, file_metadata=file_metadata,
                          get_priority_info=get_priority_info, get_ctcss_info=get_ctcss_info,
-                         wav_dir=wav_dir, audio_rate=audio_rate)
+                         wav_dir=wav_dir, audio_rate=audio_rate, max_ctcss_tones=max_ctcss_tones)
 
 
         # Default values

--- a/apps/frequency_manager.py
+++ b/apps/frequency_manager.py
@@ -70,6 +70,8 @@ class ConfigFrequency(FrequencyInfo):
     # itself remains the first/primary tone, kept for backward compatibility with
     # code that only expects a single value (e.g. get_ctcss_info()).
     ctcss_tones: list[float] = field(default_factory=list, init=False, repr=False)
+    ctcss_labels: list[str] = field(default_factory=list, init=False, repr=False)
+
 
     def calculate_baseband(self, center_freq: int, channel_spacing: int) -> None:
         if self.is_single:
@@ -120,6 +122,8 @@ class ConfigFrequency(FrequencyInfo):
         # Set state
         self.is_single = self.single is not None
         self.ctcss_tones = [self.ctcss] if self.ctcss is not None else []
+        self.ctcss_labels = [self.label] if (self.ctcss is not None and self.label is not None) else []
+
 
     def _validate_frequency_types(self):
         """Ensure all frequency values are floats if provided"""
@@ -183,6 +187,9 @@ class ChannelFrequency(FrequencyInfo):
     bb: int
     active: bool
     hanging: bool
+    matched_ctcss: float | None = field(default=None)  # actively matched CTCSS tone during a live transmission; None when idle or unmatched
+    ctcss_tones: list[float] = field(default_factory=list)
+
 
 
 @dataclass(kw_only=True)
@@ -202,6 +209,7 @@ class ChannelMessage(FrequencyInfo):
     classification: Optional[str] = None
     detail: Optional[str] = None
     signal_db: Optional[int] = None
+    matched_ctcss: float | None = field(default=None)  # CTCSS tone that matched and opened squelch for this transmission
 
 
 FrequencyList: TypeAlias = list[ConfigFrequency]
@@ -216,6 +224,7 @@ class FrequencyConfiguration:
     file_name: Optional[Path] = None
     disable_lockout: bool
     disable_priority: bool
+    max_ctcss_tones: int = 0
 
 
 class FrequencyManager:
@@ -295,6 +304,16 @@ class FrequencyManager:
         '''
         wanted = ConfigFrequency(**entry)
 
+        if wanted.ctcss is not None:
+            if self.config.max_ctcss_tones <= 0:
+                raise ValueError(
+                    f"CTCSS is disabled (max_ctcss_tones={self.config.max_ctcss_tones}) "
+                    f"but frequency config specifies ctcss: {wanted.ctcss}")
+            if len(wanted.ctcss_tones) > self.config.max_ctcss_tones:
+                raise ValueError(
+                    f"Frequency config specifies {len(wanted.ctcss_tones)} CTCSS tones "
+                    f"but max_ctcss_tones is limited to {self.config.max_ctcss_tones}")
+
         # use the dataclass __eq__ functions to look for matches
         matching_frequencies = [existing for existing in self.frequencies
                                 if wanted == existing]
@@ -334,6 +353,16 @@ class FrequencyManager:
             entry (dict): The raw dict passed to add(), used to distinguish
                 "not specified" from "explicitly set" for conflict checks
         '''
+        if self.config.max_ctcss_tones <= 0:
+            raise ValueError(
+                f"CTCSS is disabled (max_ctcss_tones={self.config.max_ctcss_tones}) "
+                f"but frequency config specifies ctcss: {wanted.ctcss}")
+
+        if len(existing.ctcss_tones) >= self.config.max_ctcss_tones:
+            raise ValueError(
+                f"Cannot merge CTCSS tone {wanted.ctcss} into "
+                f"{existing.label!r}: exceeds max_ctcss_tones limit of {self.config.max_ctcss_tones}")
+
         if 'priority' in entry and existing.priority is not None and wanted.priority != existing.priority:
             raise ValueError(
                 f"Cannot merge CTCSS tone {wanted.ctcss} into "
@@ -341,9 +370,11 @@ class FrequencyManager:
                 f"with existing priority {existing.priority}")
 
         existing.ctcss_tones.append(wanted.ctcss)
+        existing.ctcss_labels.append(wanted.label or existing.label or "")
         logging.debug(
             f'Merged CTCSS tone {wanted.ctcss} into existing frequency '
             f'{existing.label!r} (tones now {existing.ctcss_tones})')
+
 
     async def change(self, entry: dict) -> FrequencyList:
         '''
@@ -369,6 +400,11 @@ class FrequencyManager:
                 for field in ['label', 'priority', 'locked']:
                     if field in entry:
                         setattr(frequency, field, entry[field])
+
+                # CTCSS tone merging in change()
+                if 'ctcss' in entry and entry['ctcss'] is not None:
+                    if entry['ctcss'] not in frequency.ctcss_tones:
+                        self._merge_ctcss_tone(frequency, new_values, entry)
 
                 return self.frequencies
 
@@ -544,22 +580,31 @@ class FrequencyManager:
                 self.center_freq, self.channel_spacing)
 
 
-    def get_label(self, rf: float) -> str | None:
+    def get_label(self, rf: float, ctcss: float | None = None) -> str | None:
         '''
         Get the label for a frequency.  If there is not a label for the frequency then
         return the label for the range of frequencies (if any)
 
         Args:
             rf (float): Radio frequency of tuned channel
+            ctcss (float, optional): Matched CTCSS tone frequency
         '''
         range_label: str | None = None
         for freq_entry in self.frequencies:
             if freq_entry.is_single:
                 if freq_entry.single == rf:
+                    if ctcss is not None and ctcss in freq_entry.ctcss_tones:
+                        idx = freq_entry.ctcss_tones.index(ctcss)
+                        if idx < len(freq_entry.ctcss_labels):
+                            return freq_entry.ctcss_labels[idx]
                     return freq_entry.label
             else:
                 if freq_entry.lo <= rf <= freq_entry.hi:
                     range_label = freq_entry.label
+                    if ctcss is not None and ctcss in freq_entry.ctcss_tones:
+                        idx = freq_entry.ctcss_tones.index(ctcss)
+                        if idx < len(freq_entry.ctcss_labels):
+                            range_label = freq_entry.ctcss_labels[idx]
 
         return range_label
 

--- a/apps/h2m_parser.py
+++ b/apps/h2m_parser.py
@@ -224,6 +224,10 @@ class CLParser(object):
                           dest="file_metadata", default="",
                           help="Comma-separated list of metadata fields to include in output filenames (e.g. priority,strength)")
 
+        parser.add_argument("--max-ctcss-tones", type=int,
+                          dest="max_ctcss_tones", default=0,
+                          help="Maximum number of CTCSS tones configured per frequency (default: 0, disabled for performance)")
+
         options = parser.parse_args()
         self.print_help = parser.print_help
         self.parser_args = parser.parse_args
@@ -290,7 +294,8 @@ class CLParser(object):
         self.frequency_configuration = FrequencyConfiguration(
             file_name=file_name,
             disable_lockout=bool(options.disable_lockout),
-            disable_priority=bool(options.disable_priority)
+            disable_priority=bool(options.disable_priority),
+            max_ctcss_tones=int(options.max_ctcss_tones)
         )
 
         self.channel_log_params = ChannelLogParams(
@@ -338,10 +343,10 @@ class CLParser(object):
         self.file_metadata: list[str] = []
         if options.file_metadata:
             fields = [f.strip().lower() for f in options.file_metadata.split(',')]
-            valid_fields = {'priority', 'strength'}
+            valid_fields = {'priority', 'strength', 'ctcss'}
             for field in fields:
                 if field not in valid_fields:
-                    parser.error(f"Unsupported metadata field: '{field}'. Supported fields: priority, strength")
+                    parser.error(f"Unsupported metadata field: '{field}'. Supported fields: priority, strength, ctcss")
             self.file_metadata = fields
 
 

--- a/apps/receiver.py
+++ b/apps/receiver.py
@@ -56,7 +56,8 @@ class Receiver(gr.top_block):
                  classifier_params: ClassifierParams, notify_scanner: Callable,
                  agc: bool, file_metadata: list[str] | None = None,
                  get_priority_info: Callable[[int], tuple[int | None, bool]] | None = None,
-                 get_ctcss_info: Callable[[int], float | None] | None = None,
+                 get_ctcss_info: Callable[[float], list[float]] | None = None,
+                 max_ctcss_tones: int = 0,
                  source_type: str = "hardware", source_file: str | None = None,
                  wav_dir: str = "wav", center_freq: int = int(144E6)):
 
@@ -157,6 +158,7 @@ class Receiver(gr.top_block):
         self.file_metadata = file_metadata if file_metadata is not None else []
         self.get_priority_info = get_priority_info
         self.get_ctcss_info = get_ctcss_info
+        self.max_ctcss_tones = max_ctcss_tones
 
         # -----------Flow for Demod--------------
 
@@ -174,6 +176,7 @@ class Receiver(gr.top_block):
                                                         file_metadata=self.file_metadata,
                                                         get_priority_info=self.get_priority_info,
                                                         get_ctcss_info=self.get_ctcss_info,
+                                                        max_ctcss_tones=self.max_ctcss_tones,
                                                         wav_dir=self._wav_dir))
             elif type_demod == 1:
                 self.demodulators.append(TunerDemodAM(self.samp_rate,
@@ -185,6 +188,7 @@ class Receiver(gr.top_block):
                                                       file_metadata=self.file_metadata,
                                                       get_priority_info=self.get_priority_info,
                                                       get_ctcss_info=self.get_ctcss_info,
+                                                      max_ctcss_tones=self.max_ctcss_tones,
                                                       wav_dir=self._wav_dir))
             elif type_demod == 2:
                 self.demodulators.append(TunerDemodWBFM(self.samp_rate,
@@ -196,6 +200,7 @@ class Receiver(gr.top_block):
                                                         file_metadata=self.file_metadata,
                                                         get_priority_info=self.get_priority_info,
                                                         get_ctcss_info=self.get_ctcss_info,
+                                                        max_ctcss_tones=self.max_ctcss_tones,
                                                         wav_dir=self._wav_dir))
             else:
                 raise Exception(f'Invalid demodulator type: {type_demod}')
@@ -343,6 +348,18 @@ class Receiver(gr.top_block):
         for demodulator in self.demodulators:
             center_freqs.append(demodulator.center_freq)
         return center_freqs
+
+    def get_demod_freq_map(self) -> dict[int, object]:
+        """Returns a mapping of baseband center frequency to demodulator.
+
+        Allows O(1) lookup of a demodulator by its tuned frequency, which is
+        more efficient than the O(N) linear scan that would otherwise be needed
+        when iterating over channels in the scanner sweep.
+
+        Returns:
+            dict[int, BaseTuner]: {center_freq_hz: demodulator} for all demodulators
+        """
+        return {d.center_freq: d for d in self.demodulators}
 
     def __del__(self):
         """Called when the object is destroyed."""

--- a/apps/scanner.py
+++ b/apps/scanner.py
@@ -120,7 +120,11 @@ class Scanner(object):
                                        self.got_channel_activity, agc,
                                        file_metadata=self.file_metadata,
                                        get_priority_info=self.frequency_manager.get_priority_info,
-                                       get_ctcss_info=self.frequency_manager.get_ctcss_info)
+                                       # kept the kwarg name get_ctcss_info (see BaseTuner) even
+                                       # though it now points at get_ctcss_tones() and returns a
+                                       # list of valid tones rather than a single one.
+                                       get_ctcss_info=self.frequency_manager.get_ctcss_tones,
+                                       max_ctcss_tones=frequency_configuration.max_ctcss_tones)
 
         # Get the hardware sample rate
         self.samp_rate = self.receiver.samp_rate
@@ -338,7 +342,8 @@ class Scanner(object):
 
         # If a demodulator is not in channel list than it is waiting for hang time to end
         # There is no activity on it so it was not in the scan
-        demod_freqs = self.receiver.get_demod_freqs()
+        demod_map = self.receiver.get_demod_freq_map()
+        demod_freqs = list(demod_map.keys())
         for demod_freq in demod_freqs:
             if demod_freq != 0 and demod_freq not in all_channels:
                all_channels = np.append(all_channels, demod_freq)
@@ -351,6 +356,10 @@ class Scanner(object):
             is_active = channel in demod_freqs and channel in active_channels
             is_hanging = channel in demod_freqs and channel not in active_channels
 
+            matched_tone = None
+            if channel in demod_map:
+                matched_tone = demod_map[channel].matched_ctcss_tone
+
             idx = 0 if priority is not None else len(sweep)  # priority channels up front
             sweep.insert(idx, ChannelFrequency(bb=channel,
                                       rf=frequency,
@@ -359,7 +368,10 @@ class Scanner(object):
                                       priority=priority,
                                       hanging=is_hanging,
                                       ctcss=self.frequency_manager.get_ctcss_info(frequency),
-                                      label=self.frequency_manager.get_label(frequency)))
+                                      matched_ctcss=matched_tone,
+                                      label=self.frequency_manager.get_label(frequency, matched_tone),
+                                      ctcss_tones=self.frequency_manager.get_ctcss_tones(frequency)))
+
 
         return sweep
 
@@ -460,7 +472,8 @@ class Scanner(object):
             return
 
         # embellish the message with frequency information
-        msg.label = self.frequency_manager.get_label(msg.rf)
+        msg.label = self.frequency_manager.get_label(msg.rf, msg.matched_ctcss)
+
         msg.priority = self.frequency_manager.is_priority(msg.bb)   # TODO: is_priority only takes base band frequency
 
         await self.channel_logger.log(msg)  # off events or nothing to note

--- a/apps/tests/conftest.py
+++ b/apps/tests/conftest.py
@@ -196,7 +196,8 @@ def receiver_factory(test_wav_dir, mock_notify_scanner, mock_get_priority_info):
         play: bool = False,
         agc: bool = False,
         file_metadata: list[str] | None = None,
-        get_ctcss_info: Callable[[int], float | None] | None = None
+        get_ctcss_info: Callable[[float], list[float]] | None = None,
+        max_ctcss_tones: int = 3
     ) -> Receiver:
         classifier_params = ClassifierParams(
             wanted={'V': False, 'D': False, 'S': False},
@@ -219,6 +220,7 @@ def receiver_factory(test_wav_dir, mock_notify_scanner, mock_get_priority_info):
             file_metadata=file_metadata,
             get_priority_info=mock_get_priority_info,
             get_ctcss_info=get_ctcss_info,
+            max_ctcss_tones=max_ctcss_tones,
             source_type="file",
             source_file=source_file,
             wav_dir=test_wav_dir,

--- a/apps/tests/test_busy_net.py
+++ b/apps/tests/test_busy_net.py
@@ -22,21 +22,18 @@ demodulator noise floor compresses the ratio between loud and quiet speakers
 in a way that makes the threshold fragile; measuring energy at each speaker's
 specific tone frequency sidesteps that entirely.
 
-Although not required for the test itself, these frequencies are synced with
-`doc/frequencies-example.yaml`.  See `doc/simulate-radio-tranmissions.md` for details.
-
 Scenario narrative (synthetic labels, not real-world frequencies):
 
   RF centre: 462.550 MHz  |  IQ sample rate: 1 Msps  |  Duration: 10 s
 
-  - "Local repeater output"    462.730 MHz, CSQ (no CTCSS), two speakers:
+  - "Warehouse Ops"    462.730 MHz, CSQ (no CTCSS), two speakers:
       base station (strong, hot modulation) and handheld (weaker, softer).
       Each trades two exchanges.
 
-  - "Some dispatch"  462.400 MHz, CTCSS 100.0 Hz, two speakers:
+  - "Security Patrol"  462.400 MHz, CTCSS 100.0 Hz, two speakers:
       patrol unit and dispatch, tone-squelched repeater pair.
 
-  - "General talkaround" 462.610 MHz, CTCSS 167.9 Hz:
+  - "Maintenance Crew" 462.610 MHz, CTCSS 167.9 Hz:
       single brief weak/distant transmission, borrows the third demodulator.
 
   - Background QRM     462.290 MHz, CTCSS 71.9 Hz:
@@ -378,9 +375,9 @@ async def test_busy_net_realistic_scanning_session(receiver_factory, tmp_path, m
 
     def mock_ctcss_info(rf_freq_mhz: float):
         if abs(rf_freq_mhz - patrol_rf_mhz) < 1e-4:
-            return PATROL_CTCSS_HZ
+            return [PATROL_CTCSS_HZ]
         if abs(rf_freq_mhz - maintenance_rf_mhz) < 1e-4:
-            return MAINTENANCE_CTCSS_HZ
+            return [MAINTENANCE_CTCSS_HZ]
         return None  # CSQ for Warehouse Ops and anything else
 
     rx = receiver_factory(

--- a/apps/tests/test_channel_loggers.py
+++ b/apps/tests/test_channel_loggers.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import MagicMock
+from channel_loggers import ChannelLogParams, FixedField, JsonToServer
+from frequency_manager import ChannelMessage
+
+@pytest.mark.asyncio
+async def test_fixed_field_logger(tmp_path):
+    log_file = tmp_path / "channel.log"
+    params = ChannelLogParams(type="fixed-field", target=str(log_file), timeout=0)
+    logger = FixedField(params)
+
+    # 1. Message WITH matched CTCSS
+    msg1 = ChannelMessage(
+        state="on",
+        rf=145.5,
+        bb=0,
+        channel=0,
+        priority=1,
+        classification="V",
+        matched_ctcss=100.0,
+        file="test1.wav"
+    )
+    await logger.log(msg1)
+
+    # 2. Message WITHOUT matched CTCSS
+    msg2 = ChannelMessage(
+        state="off",
+        rf=145.5,
+        bb=0,
+        channel=0,
+        priority=None,
+        classification=None,
+        matched_ctcss=None,
+        file="test2.wav"
+    )
+    await logger.log(msg2)
+
+    assert log_file.exists()
+    lines = log_file.read_text().splitlines()
+    assert len(lines) == 2
+
+    # Verify formatting of msg1: matched_ctcss '100.0  ' should be present right before the filename
+    line1 = lines[0]
+    # Check that we can find the tone and filename in the correct order/formatting
+    assert "100.0  " in line1
+    assert "test1.wav" in line1
+
+    # Verify formatting of msg2: matched_ctcss is empty/omitted
+    line2 = lines[1]
+    # In line 2, the matched CTCSS column should be empty (7 spaces)
+    # The file part is test2.wav
+    assert "test2.wav" in line2
+    # Ensure "100.0" is not in line2
+    assert "100.0" not in line2
+
+
+@pytest.mark.asyncio
+async def test_json_to_server_logger():
+    params = ChannelLogParams(type="json-server", target="http://example.com/log", timeout=0)
+    logger = JsonToServer(params)
+
+    # Mock requests post directly on the instance's requests object
+    mock_post = MagicMock()
+    setattr(logger.requests, "post", mock_post)
+
+    msg = ChannelMessage(
+        state="on",
+        rf=145.5,
+        bb=0,
+        channel=0,
+        priority=1,
+        classification="V",
+        matched_ctcss=141.3,
+        file="test.wav"
+    )
+    await logger.log(msg)
+
+    # Verify remote call was made with expected JSON body
+    mock_post.assert_called_once()
+    called_args, called_kwargs = mock_post.call_args
+    assert called_args[0] == "http://example.com/log"
+
+    posted_json = called_kwargs["json"]
+    assert posted_json["matched_ctcss"] == 141.3
+    assert posted_json["state"] == "on"
+    assert posted_json["rf"] == 145.5
+    assert posted_json["file"] == "test.wav"

--- a/apps/tests/test_filename_generation.py
+++ b/apps/tests/test_filename_generation.py
@@ -273,3 +273,37 @@ def test_persist_filename_strength_metadata_none_signal() -> None:
     assert msg.file == "wav/460.1250_20260531_160622.345.wav"
     assert os.path.exists("wav/460.1250_20260531_160622.345.wav")
 
+
+def test_persist_filename_with_ctcss() -> None:
+    # Test that when 'ctcss' metadata is requested and a tone is matched, it is appended to the filename
+    tuner = MockTuner(None, lambda msg: None, file_metadata=["ctcss"])
+    tuner.matched_ctcss_tone = 103.5
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_103.5Hz_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_103.5Hz_20260531_160622.345.wav")
+
+
+def test_persist_filename_with_ctcss_none() -> None:
+    # Test that when 'ctcss' metadata is requested, but matched_ctcss_tone is None, the ctcss segment is omitted
+    tuner = MockTuner(None, lambda msg: None, file_metadata=["ctcss"])
+    tuner.matched_ctcss_tone = None
+
+    temp_file = "wav/tmp/460.1250_20260531_160622.345.wav"
+    with open(temp_file, "wb") as f:
+        f.write(b"0" * 100)
+
+    tuner.set_temp_file(temp_file)
+
+    msg = tuner._persist_wavfile(rf_center_freq=460000000)
+    assert msg is not None
+    assert msg.file == "wav/460.1250_20260531_160622.345.wav"
+    assert os.path.exists("wav/460.1250_20260531_160622.345.wav")
+

--- a/apps/tests/test_frequency_manager.py
+++ b/apps/tests/test_frequency_manager.py
@@ -16,7 +16,7 @@ LAST_ENTRY = -1
 async def fm_empty() -> FrequencyManager:
 
     config = FrequencyConfiguration(
-        file_name=None, disable_lockout=False, disable_priority=False)
+        file_name=None, disable_lockout=False, disable_priority=False, max_ctcss_tones=3)
     channel_spacing = CHANNEL_SPACING
 
     frequency_manager = FrequencyManager(config, channel_spacing)
@@ -29,7 +29,7 @@ async def fm_empty() -> FrequencyManager:
 @pytest.fixture
 async def fm_with_entries() -> FrequencyManager:
 
-    config = FrequencyConfiguration(file_name=TEST_DIR / "frequency_config_for_testing.yaml", disable_lockout=False, disable_priority=False)
+    config = FrequencyConfiguration(file_name=TEST_DIR / "frequency_config_for_testing.yaml", disable_lockout=False, disable_priority=False, max_ctcss_tones=3)
     channel_spacing = CHANNEL_SPACING
 
     frequency_manager = FrequencyManager(config, channel_spacing)
@@ -996,3 +996,85 @@ async def test_get_priority_info(fm_empty):
     p, is_auto = fm_empty.get_priority_info(60000)
     assert p is None
     assert is_auto is False
+
+
+@pytest.mark.asyncio
+async def test_max_ctcss_tones_limit(fm_empty):
+    """Test that max_ctcss_tones limits CTCSS tone count and throws validation errors."""
+    from frequency_manager import FrequencyConfiguration, FrequencyManager
+
+    # Set up config with max_ctcss_tones = 2
+    config_2 = FrequencyConfiguration(
+        file_name=None,
+        disable_lockout=False,
+        disable_priority=False,
+        max_ctcss_tones=2
+    )
+    fm_2 = FrequencyManager(config_2, channel_spacing=5000)
+
+    # 1. Add first CTCSS tone: OK
+    await fm_2.add({'single': 144.390, 'ctcss': 100.0, 'label': 'Frequency'})
+    assert fm_2.frequencies[0].ctcss_tones == [100.0]
+
+    # 2. Add second CTCSS tone (merge): OK
+    await fm_2.add({'single': 144.390, 'ctcss': 141.3})
+    assert fm_2.frequencies[0].ctcss_tones == [100.0, 141.3]
+
+    # 3. Add third CTCSS tone (merge): should raise ValueError due to limit
+    with pytest.raises(ValueError, match="exceeds max_ctcss_tones limit"):
+        await fm_2.add({'single': 144.390, 'ctcss': 151.4})
+
+    # Set up config with max_ctcss_tones = 0 (CTCSS disabled)
+    config_0 = FrequencyConfiguration(
+        file_name=None,
+        disable_lockout=False,
+        disable_priority=False,
+        max_ctcss_tones=0
+    )
+    fm_0 = FrequencyManager(config_0, channel_spacing=5000)
+
+    # 4. Adding with CTCSS should fail immediately when max_ctcss_tones is 0
+    with pytest.raises(ValueError, match="CTCSS is disabled"):
+        await fm_0.add({'single': 144.390, 'ctcss': 100.0, 'label': 'Frequency'})
+
+
+@pytest.mark.asyncio
+async def test_change_ctcss_merging(fm_empty):
+    """Test that change() supports CTCSS tone merging and respects max limits."""
+    # Default max_ctcss_tones is 3
+    # 1. Add a frequency with a CTCSS tone
+    await fm_empty.add({'single': 144.390, 'ctcss': 100.0, 'label': 'Frequency'})
+    assert fm_empty.frequencies[0].ctcss_tones == [100.0]
+
+    # 2. Merge another CTCSS tone via change()
+    await fm_empty.change({'single': 144.390, 'ctcss': 141.3})
+    assert fm_empty.frequencies[0].ctcss_tones == [100.0, 141.3]
+
+    # 3. Merge a third tone via change()
+    await fm_empty.change({'single': 144.390, 'ctcss': 151.4})
+    assert fm_empty.frequencies[0].ctcss_tones == [100.0, 141.3, 151.4]
+
+    # 4. Merging a fourth tone should fail (max limit is 3)
+    with pytest.raises(ValueError, match="exceeds max_ctcss_tones limit"):
+        await fm_empty.change({'single': 144.390, 'ctcss': 162.2})
+
+
+@pytest.mark.asyncio
+async def test_get_label_with_ctcss(fm_empty):
+    """Test that get_label correctly resolves the label matching a specific CTCSS tone."""
+    # 1. Add multiple entries for same frequency with different CTCSS tones and labels
+    await fm_empty.add({'single': 144.390, 'ctcss': 100.0, 'label': 'Tone 100'})
+    await fm_empty.add({'single': 144.390, 'ctcss': 141.3, 'label': 'Tone 141'})
+    await fm_empty.add({'single': 144.390, 'ctcss': 151.4, 'label': 'Tone 151'})
+
+    # 2. Assert that get_label without ctcss returns the primary label
+    assert fm_empty.get_label(144.390) == 'Tone 100'
+
+    # 3. Assert that get_label with specific ctcss returns the corresponding label
+    assert fm_empty.get_label(144.390, 100.0) == 'Tone 100'
+    assert fm_empty.get_label(144.390, 141.3) == 'Tone 141'
+    assert fm_empty.get_label(144.390, 151.4) == 'Tone 151'
+
+    # 4. Assert that get_label with unmatched/unknown ctcss falls back to primary label
+    assert fm_empty.get_label(144.390, 88.5) == 'Tone 100'
+

--- a/apps/tests/test_receiver.py
+++ b/apps/tests/test_receiver.py
@@ -490,8 +490,20 @@ async def test_fft_spectrum_probe(receiver_factory, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_ctcss_match(receiver_factory, tmp_path):
+async def test_ctcss_match(receiver_factory, tmp_path, monkeypatch):
     """Test that NBFM squelch opens when the correct CTCSS tone is present and saves a WAV file."""
+    from receiver import Receiver
+    from gnuradio import blocks, gr
+
+    # Throttled file source for real-time timing verification
+    def throttled_init_file_source(self, source_file, ask_samp_rate, center_freq):
+        file_src = blocks.file_source(gr.sizeof_gr_complex, source_file, repeat=False)
+        throttle = blocks.throttle(gr.sizeof_gr_complex, ask_samp_rate)
+        self.connect(file_src, throttle)
+        return throttle, ask_samp_rate, center_freq
+
+    monkeypatch.setattr(Receiver, "_init_file_source", throttled_init_file_source)
+
     iq_file = tmp_path / "signal_ctcss_match.iq"
 
     # Generate NBFM signal at +30 kHz offset with CTCSS tone 100.0 Hz
@@ -515,7 +527,7 @@ async def test_ctcss_match(receiver_factory, tmp_path):
 
     # Mock that returns 100.0 for any query (CTCSS configured to 100 Hz)
     def mock_ctcss_info(bb):
-        return 100.0
+        return [100.0]
 
     rx = receiver_factory(
         source_file=str(iq_file),
@@ -532,6 +544,13 @@ async def test_ctcss_match(receiver_factory, tmp_path):
 
     # Run flowgraph
     rx.start()
+
+    # Wait for the signal to start playing (0.8s, well within active tone window of 0.2s-1.2s)
+    # and confirm it matched (latching ctcss_matched = True)
+    await asyncio.sleep(0.8)
+    assert rx.demodulators[0].is_ctcss_mismatched() == False
+    assert rx.demodulators[0].ctcss_matched == True
+
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, rx.wait)
 
@@ -554,52 +573,66 @@ async def test_ctcss_matching_logic_mocked():
     self = MagicMock()
     self.channel = 1
     self._ctcss_enabled = True
+    self._active_tone_count = 2  # simulate a 2-tone channel (e.g. primary + backup PL)
     self.ctcss_matched = False
     self.ctcss_checked = False
     self.discard_current = False
     self._ctcss_start_time = time.time()
-    self._CTCSS_GRACE_PERIOD_S = 0.4
+    self._CTCSS_GRACE_PERIOD_S = BaseTuner._CTCSS_GRACE_PERIOD_S
     self.ctcss_level = 0.0001
 
     # Bind the methods from BaseTuner
     self.is_ctcss_mismatched = BaseTuner.is_ctcss_mismatched.__get__(self)
     self.set_center_freq = BaseTuner.set_center_freq.__get__(self)
 
-    # Mock squelch blocks and other requirements for set_center_freq
+    # Mock the N parallel CTCSS chains and other requirements for set_center_freq.
+    # Only indices < _active_tone_count are consulted by is_ctcss_mismatched.
+    self._ctcss_squelches = [MagicMock(), MagicMock(), MagicMock()]
     self.analog_pwr_squelch_cc.unmuted.return_value = True
-    self.analog_ctcss_squelch_ff.unmuted.return_value = False
-    self.analog_ctcss_squelch_ff.frequency.return_value = 100.0
-    self.analog_ctcss_squelch_ff.level.return_value = 0.0001
+    for squelch in self._ctcss_squelches:
+        squelch.unmuted.return_value = False
 
     self.notify_scanner = AsyncMock()
     self._persist_wavfile = MagicMock(return_value=None)
     self.freq_xlating_fir_filter_ccc = MagicMock()
     self.get_ctcss_info = None
 
-    # 1. In grace period (< 0.4s), should return False and set ctcss_checked = True
+    # 1. In grace period, should return False and set ctcss_checked = True
     assert self.is_ctcss_mismatched() == False
     assert self.ctcss_checked == True
     assert self.ctcss_matched == False
 
     # 2. Exceed grace period, no match yet, squelch open -> should return True (mismatch)
-    self._ctcss_start_time = time.time() - 0.5
+    self._ctcss_start_time = time.time() - (self._CTCSS_GRACE_PERIOD_S + 0.1)
     assert self.is_ctcss_mismatched() == True
     assert self.discard_current == True
 
-    # 3. Simulate matching tone detection -> should set matched=True and return False
+    # 3. Simulate matching tone detection on the SECOND (backup) tone -> should set
+    #    matched=True and return False, proving the check isn't limited to chain 0.
     self.ctcss_matched = False
     self.discard_current = False
-    self.analog_ctcss_squelch_ff.unmuted.return_value = True
+    self._ctcss_squelches[1].unmuted.return_value = True
     assert self.is_ctcss_mismatched() == False
     assert self.ctcss_matched == True
     assert self.discard_current == False
 
-    # 4. Once matched, even if CTCSS drops (unmuted=False) and grace period exceeded, should remain False (sticky!)
-    self.analog_ctcss_squelch_ff.unmuted.return_value = False
+    # 4. Once matched, even if that tone drops (unmuted=False) and grace period exceeded,
+    #    should remain False (sticky!)
+    self._ctcss_squelches[1].unmuted.return_value = False
     assert self.is_ctcss_mismatched() == False
     assert self.discard_current == False
 
-    # 5. Verify set_center_freq completed transmission discard logic
+    # 5. A third, unconfigured chain (index 2, beyond _active_tone_count=2) matching
+    #    should NOT count -- is_ctcss_mismatched must only look at active slots.
+    self.ctcss_matched = False
+    self.discard_current = False
+    self._ctcss_start_time = time.time() - (self._CTCSS_GRACE_PERIOD_S + 0.1)
+    self._ctcss_squelches[2].unmuted.return_value = True  # inactive slot -- should be ignored
+    assert self.is_ctcss_mismatched() == True
+    assert self.discard_current == True
+    self._ctcss_squelches[2].unmuted.return_value = False
+
+    # 6. Verify set_center_freq completed transmission discard logic
     self.record = True
     self._ctcss_enabled = True
     self.ctcss_checked = True
@@ -647,7 +680,7 @@ async def test_ctcss_mismatch(receiver_factory, tmp_path):
 
     # CTCSS configured to 100 Hz (mismatch!)
     def mock_ctcss_info(bb):
-        return 100.0
+        return [100.0]
 
     rx = receiver_factory(
         source_file=str(iq_file),
@@ -665,8 +698,8 @@ async def test_ctcss_mismatch(receiver_factory, tmp_path):
     # Run flowgraph
     rx.start()
 
-    # Wait for the signal to start playing (0.5s) and check mismatch
-    await asyncio.sleep(0.5)
+    # Wait for the signal to start playing (0.8s) and check mismatch
+    await asyncio.sleep(0.8)
     assert rx.demodulators[0].is_ctcss_mismatched() == True
 
     loop = asyncio.get_running_loop()
@@ -729,7 +762,7 @@ async def test_ctcss_mismatch_suppression(tmp_path):
 
             self.receiver = MockReceiver()
 
-    config = FrequencyConfiguration(file_name=None, disable_lockout=False, disable_priority=False)
+    config = FrequencyConfiguration(file_name=None, disable_lockout=False, disable_priority=False, max_ctcss_tones=3)
     scanner = MockScanner(config, channel_spacing=5000)
 
     # Note: scanner.frequency_manager.get_ctcss_info is not directly called here since
@@ -769,6 +802,143 @@ async def test_ctcss_mismatch_suppression(tmp_path):
     await scanner._assign_channels_to_demodulators(active_channels)
     # Demodulator should now be tuned to the channel baseband frequency (30_000)
     assert demod.center_freq == 30_000
+
+
+@pytest.mark.asyncio
+async def test_ctcss_match_second_configured_tone(receiver_factory, tmp_path):
+    """
+    Test that a channel configured with TWO CTCSS tones (e.g. a repeater with a
+    primary and backup PL tone) correctly matches and records when the SECOND
+    (backup) tone is what's actually transmitted -- not just the first/primary.
+
+    This is the real-signal counterpart to the 2-tone cases in
+    test_ctcss_matching_logic_mocked / test_ctcss_dynamic_routing: those prove the
+    Python bookkeeping is right, this proves chain 1's actual GNU Radio squelch
+    block is correctly wired end-to-end (not just chain 0).
+    """
+    iq_file = tmp_path / "signal_ctcss_second_tone.iq"
+
+    # Generate NBFM signal at +30 kHz offset with the BACKUP tone (67.0 Hz), not the primary (100.0 Hz)
+    iq_data = generate_test_iq(
+        sample_rate=1.0e6,
+        duration=1.5,
+        channels=[
+            {
+                "carrier_offset": 30_000,
+                "amplitude": 1.0,
+                "audio_freq": 1000.0,
+                "audio_dev": 3000.0,
+                "ctcss_freq": 67.0,
+                "ctcss_dev": 500.0,
+                "events": [(0.2, 1.2)]
+            }
+        ],
+        snr_db=30.0
+    )
+    iq_data.tofile(iq_file)
+
+    # Channel configured with two valid tones: primary 100.0 Hz, backup 67.0 Hz
+    def mock_ctcss_info(bb):
+        return [100.0, 67.0]
+
+    rx = receiver_factory(
+        source_file=str(iq_file),
+        sample_rate=1_000_000,
+        num_demod=1,
+        type_demod=0,  # NBFM
+        min_recording=0.2,
+        record=True,
+        get_ctcss_info=mock_ctcss_info
+    )
+
+    await rx.demodulators[0].set_center_freq(30_000, 144_000_000)
+    rx.set_squelch(-50)
+    assert rx.demodulators[0]._active_tone_count == 2
+
+    # Run flowgraph
+    rx.start()
+
+    # Wait for the signal to start playing and confirm it matched (via chain 1, not chain 0)
+    await asyncio.sleep(0.5)
+    assert rx.demodulators[0]._ctcss_squelches[0].unmuted() == False  # primary tone never present
+    assert rx.demodulators[0]._ctcss_squelches[1].unmuted() == True   # backup tone is present
+    assert rx.demodulators[0].is_ctcss_mismatched() == False
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, rx.wait)
+
+    # De-tune to persist WAV file
+    await rx.demodulators[0].set_center_freq(0, 144_000_000)
+
+    # Verify output file creation -- matched via the second configured tone
+    wav_files = glob.glob(os.path.join(rx._wav_dir, "*.wav"))
+    assert len(wav_files) == 1, f"Expected 1 WAV (matched via backup tone), found {wav_files}"
+
+
+@pytest.mark.asyncio
+async def test_ctcss_mismatch_with_two_configured_tones(receiver_factory, tmp_path):
+    """
+    Test that a channel configured with TWO CTCSS tones still correctly reports a
+    mismatch (and discards the recording) when the transmitted tone matches
+    NEITHER configured tone.
+    """
+    iq_file = tmp_path / "signal_ctcss_two_tone_mismatch.iq"
+
+    # Transmitted tone (150.0 Hz) matches neither of the two configured tones
+    iq_data = generate_test_iq(
+        sample_rate=1.0e6,
+        duration=1.5,
+        channels=[
+            {
+                "carrier_offset": 30_000,
+                "amplitude": 1.0,
+                "audio_freq": 1000.0,
+                "audio_dev": 3000.0,
+                "ctcss_freq": 150.0,
+                "ctcss_dev": 500.0,
+                "events": [(0.2, 1.2)]
+            }
+        ],
+        snr_db=30.0
+    )
+    iq_data.tofile(iq_file)
+
+    # Channel configured with two valid tones, neither of which is 150.0 Hz
+    def mock_ctcss_info(bb):
+        return [100.0, 67.0]
+
+    rx = receiver_factory(
+        source_file=str(iq_file),
+        sample_rate=1_000_000,
+        num_demod=1,
+        type_demod=0,  # NBFM
+        min_recording=0.2,
+        record=True,
+        get_ctcss_info=mock_ctcss_info
+    )
+
+    await rx.demodulators[0].set_center_freq(30_000, 144_000_000)
+    rx.set_squelch(-50)
+    assert rx.demodulators[0]._active_tone_count == 2
+
+    # Run flowgraph
+    rx.start()
+
+    # Wait for the signal to start playing (0.8s) and check mismatch
+    await asyncio.sleep(0.8)
+    assert rx.demodulators[0]._ctcss_squelches[0].unmuted() == False
+    assert rx.demodulators[0]._ctcss_squelches[1].unmuted() == False
+    assert rx.demodulators[0].is_ctcss_mismatched() == True
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, rx.wait)
+
+    # De-tune
+    await rx.demodulators[0].set_center_freq(0, 144_000_000)
+
+    # Verify no file is saved -- neither configured tone matched
+    wav_files = glob.glob(os.path.join(rx._wav_dir, "*.wav"))
+    assert len(wav_files) == 0, f"Expected 0 WAV due to two-tone mismatch, found {wav_files}"
 
 
 @pytest.mark.asyncio
@@ -833,10 +1003,13 @@ async def test_ctcss_dynamic_routing(receiver_factory, tmp_path):
     iq_file = tmp_path / "signal_empty.iq"
     np.zeros(1000, dtype=np.complex64).tofile(iq_file)
 
-    # Mock that returns 100.0 Hz CTCSS for 144.03 MHz, but None for others
+    # Mock that returns [100.0] Hz CTCSS for 144.03 MHz, [100.0, 67.0] for 144.06 MHz
+    # (a second, multi-tone channel), and None for others
     def mock_ctcss_info(rf_freq):
         if abs(rf_freq - 144.03) < 1e-4:
-            return 100.0
+            return [100.0]
+        if abs(rf_freq - 144.06) < 1e-4:
+            return [100.0, 67.0]
         return None
 
     rx = receiver_factory(
@@ -855,40 +1028,64 @@ async def test_ctcss_dynamic_routing(receiver_factory, tmp_path):
     assert demod._is_started == False
     assert demod._ctcss_enabled == False
 
-    # Tune to 30 kHz (144.030 MHz) -> CTCSS tone is 100.0 Hz.
+    # Tune to 30 kHz (144.030 MHz) -> CTCSS tone is [100.0] Hz.
     # Flowgraph is not started, so it should update _ctcss_enabled but NOT change gains (remains 1.0/0.0)
     await demod.set_center_freq(30_000, 144_000_000)
     assert demod._ctcss_enabled == True
+    assert demod._active_tone_count == 1
     assert demod._bypass_gain.k() == 1.0
-    assert demod._ctcss_gain.k() == 0.0
+    assert demod._ctcss_gains[0].k() == 0.0
 
-    # Start the receiver -> should update gains (bypass=0.0, ctcss=1.0) since _ctcss_enabled is True
+    # Start the receiver -> should update gains (bypass=0.0, chain 0=1.0) since _ctcss_enabled is True
     rx.start()
     assert demod._is_started == True
     assert demod._bypass_gain.k() == 0.0
-    assert demod._ctcss_gain.k() == 1.0
+    assert demod._ctcss_gains[0].k() == 1.0
 
     # Tune to 50 kHz (144.050 MHz) -> CTCSS tone is None (CSQ mode).
-    # Since flowgraph is started, it should immediately switch gains to bypass (bypass=1.0, ctcss=0.0)
+    # Since flowgraph is started, it should immediately switch gains to bypass (bypass=1.0, all ctcss chains=0.0)
     await demod.set_center_freq(50_000, 144_000_000)
     assert demod._ctcss_enabled == False
     assert demod._bypass_gain.k() == 1.0
-    assert demod._ctcss_gain.k() == 0.0
+    for gain in demod._ctcss_gains:
+        assert gain.k() == 0.0
 
-    # Tune back to 30 kHz (144.030 MHz) -> CTCSS tone is 100.0 Hz again.
-    # Should immediately switch gains back to CTCSS (bypass=0.0, ctcss=1.0)
+    # Tune back to 30 kHz (144.030 MHz) -> CTCSS tone is [100.0] Hz again.
+    # Should immediately switch gains back to CTCSS (bypass=0.0, chain 0=1.0)
     await demod.set_center_freq(30_000, 144_000_000)
     assert demod._ctcss_enabled == True
     assert demod._bypass_gain.k() == 0.0
-    assert demod._ctcss_gain.k() == 1.0
+    assert demod._ctcss_gains[0].k() == 1.0
+
+    # Tune to 60 kHz (144.060 MHz) -> two configured tones, [100.0, 67.0].
+    # Both chain 0 and chain 1 should be active; chain 2 (unused slot) should stay off.
+    await demod.set_center_freq(60_000, 144_000_000)
+    assert demod._ctcss_enabled == True
+    assert demod._active_tone_count == 2
+    assert demod._bypass_gain.k() == 0.0
+    assert demod._ctcss_gains[0].k() == 1.0
+    assert demod._ctcss_gains[1].k() == 1.0
+    assert demod._ctcss_gains[2].k() == 0.0
 
     rx.stop()
     rx.wait()
 
 
 @pytest.mark.asyncio
-async def test_ctcss_wbfm_match(receiver_factory, tmp_path):
+async def test_ctcss_wbfm_match(receiver_factory, tmp_path, monkeypatch):
     """Test that WBFM squelch opens when the correct CTCSS tone is present and saves a WAV file."""
+    from receiver import Receiver
+    from gnuradio import blocks, gr
+
+    # Throttled file source for real-time timing verification
+    def throttled_init_file_source(self, source_file, ask_samp_rate, center_freq):
+        file_src = blocks.file_source(gr.sizeof_gr_complex, source_file, repeat=False)
+        throttle = blocks.throttle(gr.sizeof_gr_complex, ask_samp_rate)
+        self.connect(file_src, throttle)
+        return throttle, ask_samp_rate, center_freq
+
+    monkeypatch.setattr(Receiver, "_init_file_source", throttled_init_file_source)
+
     iq_file = tmp_path / "signal_ctcss_wbfm_match.iq"
 
     # Generate WBFM signal at -100 kHz offset with CTCSS tone 100.0 Hz
@@ -912,7 +1109,7 @@ async def test_ctcss_wbfm_match(receiver_factory, tmp_path):
 
     # Mock that returns 100.0 for any query (CTCSS configured to 100 Hz)
     def mock_ctcss_info(bb):
-        return 100.0
+        return [100.0]
 
     rx = receiver_factory(
         source_file=str(iq_file),
@@ -929,6 +1126,13 @@ async def test_ctcss_wbfm_match(receiver_factory, tmp_path):
 
     # Run flowgraph
     rx.start()
+
+    # Wait for the signal to start playing (0.8s, well within active tone window of 0.2s-1.2s)
+    # and confirm it matched (latching ctcss_matched = True)
+    await asyncio.sleep(0.8)
+    assert rx.demodulators[0].is_ctcss_mismatched() == False
+    assert rx.demodulators[0].ctcss_matched == True
+
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, rx.wait)
 
@@ -989,7 +1193,7 @@ async def test_ctcss_recording_contamination(receiver_factory, tmp_path, monkeyp
     iq_data.tofile(iq_file)
 
     def mock_ctcss_info(bb):
-        return 100.0
+        return [100.0]
 
     rx = receiver_factory(
         source_file=str(iq_file),
@@ -1057,4 +1261,301 @@ async def test_ctcss_recording_contamination(receiver_factory, tmp_path, monkeyp
     # Specifically, the 2000 Hz tone (active in transmission 2) should be much stronger than the 1000 Hz leak.
     assert e2000 > e1000 * 2.0, f"Contamination detected! e1000 (leak) = {e1000:.2f}, e2000 (legit) = {e2000:.2f}"
 
+
+@pytest.mark.asyncio
+async def test_ctcss_sustained_match(receiver_factory, tmp_path, monkeypatch):
+    """
+    Test that CTCSS tone detection remains active/sustained throughout the transmission,
+    and correctly goes back to False when the tone stops, using a throttled real-time source.
+    """
+    from receiver import Receiver
+    from gnuradio import blocks, gr
+
+    # Monkeypatch Receiver._init_file_source to add a throttle block for real-time simulation
+    def throttled_init_file_source(self, source_file, ask_samp_rate, center_freq):
+        file_src = blocks.file_source(gr.sizeof_gr_complex, source_file, repeat=False)
+        throttle = blocks.throttle(gr.sizeof_gr_complex, ask_samp_rate)
+        self.connect(file_src, throttle)
+        return throttle, ask_samp_rate, center_freq
+
+    monkeypatch.setattr(Receiver, "_init_file_source", throttled_init_file_source)
+
+    iq_file = tmp_path / "signal_ctcss_sustained.iq"
+
+    # Generate NBFM signal at +30 kHz: CTCSS = 100.0 Hz, active from 0.2s to 1.7s.
+    # We extend duration to 2.8s so that after the transmission ends at 1.7s,
+    # there is a full 1.1s of silence. This guarantees that at least one complete
+    # Goertzel block (4000 samples = 0.5s) containing 100% silence is processed,
+    # forcing the Goertzel detector to update and mute.
+    iq_data = generate_test_iq(
+        sample_rate=1.0e6,
+        duration=2.8,
+        channels=[
+            {
+                "carrier_offset": 30_000,
+                "amplitude": 1.0,
+                "audio_freq": 1000.0,
+                "audio_dev": 3000.0,
+                "ctcss_freq": 100.0,
+                "ctcss_dev": 500.0,
+                "events": [(0.2, 1.7)]
+            }
+        ],
+        snr_db=30.0
+    )
+    iq_data.tofile(iq_file)
+
+    def mock_ctcss_info(bb):
+        return [100.0]
+
+    rx = receiver_factory(
+        source_file=str(iq_file),
+        sample_rate=1_000_000,
+        num_demod=1,
+        type_demod=0,  # NBFM
+        min_recording=0.2,
+        record=True,
+        get_ctcss_info=mock_ctcss_info
+    )
+
+    demod = rx.demodulators[0]
+    await demod.set_center_freq(30_000, 144_000_000)
+    rx.set_squelch(-50)
+
+    # Start flowgraph
+    rx.start()
+
+    # 1. At t=0.4s: tone has been present for 0.2s. Goertzel length is 4000 (0.5s),
+    # so it should NOT have matched yet.
+    await asyncio.sleep(0.4)
+    assert demod._ctcss_squelches[0].unmuted() == False
+
+    # 2. At t=0.9s: tone has been present for 0.7s. It should now be matched.
+    await asyncio.sleep(0.5)
+    assert demod._ctcss_squelches[0].unmuted() == True
+    assert demod.is_ctcss_mismatched() == False
+
+    # 3. At t=1.5s: tone has been present for 1.3s. It should remain matched.
+    await asyncio.sleep(0.6)
+    assert demod._ctcss_squelches[0].unmuted() == True
+    assert demod.is_ctcss_mismatched() == False
+
+    # 4. At t=2.6s: transmission ended at 1.7s (silence for 0.9s).
+    # Squelch should now be correctly closed (muted) because a full silent block has completed.
+    await asyncio.sleep(1.1)
+    assert demod._ctcss_squelches[0].unmuted() == False
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, rx.wait)
+
+    # De-tune
+    await demod.set_center_freq(0, 144_000_000)
+
+    # Verify file saved
+    wav_files = glob.glob(os.path.join(rx._wav_dir, "*.wav"))
+    assert len(wav_files) == 1
+
+
+@pytest.mark.asyncio
+async def test_ctcss_adjacent_tone_rejection(receiver_factory, tmp_path, monkeypatch):
+    """
+    Test that a configured standard tone (e.g. 100.0 Hz) is NOT matched when an adjacent
+    standard tone (e.g. 97.4 Hz, just 2.6 Hz away) is transmitted, proving the frequency
+    selectivity of the larger Goertzel filter.
+    """
+    from receiver import Receiver
+    from gnuradio import blocks, gr
+
+    # Throttled file source for real-time timing verification
+    def throttled_init_file_source(self, source_file, ask_samp_rate, center_freq):
+        file_src = blocks.file_source(gr.sizeof_gr_complex, source_file, repeat=False)
+        throttle = blocks.throttle(gr.sizeof_gr_complex, ask_samp_rate)
+        self.connect(file_src, throttle)
+        return throttle, ask_samp_rate, center_freq
+
+    monkeypatch.setattr(Receiver, "_init_file_source", throttled_init_file_source)
+
+    iq_file = tmp_path / "signal_ctcss_adjacent.iq"
+
+    # Generate NBFM signal at +30 kHz: CTCSS = 97.4 Hz (adjacent neighbor to 100.0 Hz), active from 0.2s to 1.7s
+    iq_data = generate_test_iq(
+        sample_rate=1.0e6,
+        duration=2.2,
+        channels=[
+            {
+                "carrier_offset": 30_000,
+                "amplitude": 1.0,
+                "audio_freq": 1000.0,
+                "audio_dev": 3000.0,
+                "ctcss_freq": 97.4,  # Transmitting adjacent tone
+                "ctcss_dev": 500.0,
+                "events": [(0.2, 1.7)]
+            }
+        ],
+        snr_db=30.0
+    )
+    iq_data.tofile(iq_file)
+
+    # Configured to 100.0 Hz
+    def mock_ctcss_info(bb):
+        return [100.0]
+
+    rx = receiver_factory(
+        source_file=str(iq_file),
+        sample_rate=1_000_000,
+        num_demod=1,
+        type_demod=0,  # NBFM
+        min_recording=0.2,
+        record=True,
+        get_ctcss_info=mock_ctcss_info
+    )
+
+    demod = rx.demodulators[0]
+    await demod.set_center_freq(30_000, 144_000_000)
+    rx.set_squelch(-50)
+
+    # Start flowgraph
+    rx.start()
+
+    # Sleep 1.0s (transmission has been active for 0.8s, well beyond Goertzel/grace period)
+    await asyncio.sleep(1.0)
+
+    # Should remain muted (False) and be flagged as mismatched (True)
+    assert demod._ctcss_squelches[0].unmuted() == False
+    assert demod.is_ctcss_mismatched() == True
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, rx.wait)
+
+    # De-tune
+    await demod.set_center_freq(0, 144_000_000)
+
+    # Verify no file is saved
+    wav_files = glob.glob(os.path.join(rx._wav_dir, "*.wav"))
+    assert len(wav_files) == 0
+
+
+@pytest.mark.asyncio
+async def test_ctcss_matched_tone_filename_metadata(receiver_factory, tmp_path, monkeypatch):
+    """
+    Test that if 'ctcss' is included in file_metadata, the matched tone is appended
+    to the persisted filename (e.g. _100.0Hz.wav) and returned in ChannelMessage.
+    """
+    from receiver import Receiver
+    from gnuradio import blocks, gr
+
+    def throttled_init_file_source(self, source_file, ask_samp_rate, center_freq):
+        file_src = blocks.file_source(gr.sizeof_gr_complex, source_file, repeat=False)
+        throttle = blocks.throttle(gr.sizeof_gr_complex, ask_samp_rate)
+        self.connect(file_src, throttle)
+        return throttle, ask_samp_rate, center_freq
+
+    monkeypatch.setattr(Receiver, "_init_file_source", throttled_init_file_source)
+
+    iq_file = tmp_path / "signal_ctcss_metadata.iq"
+
+    # Generate NBFM signal at +30 kHz: CTCSS = 100.0 Hz, active from 0.2s to 1.7s
+    iq_data = generate_test_iq(
+        sample_rate=1.0e6,
+        duration=2.2,
+        channels=[
+            {
+                "carrier_offset": 30_000,
+                "amplitude": 1.0,
+                "audio_freq": 1000.0,
+                "audio_dev": 3000.0,
+                "ctcss_freq": 100.0,
+                "ctcss_dev": 500.0,
+                "events": [(0.2, 1.7)]
+            }
+        ],
+        snr_db=30.0
+    )
+    iq_data.tofile(iq_file)
+
+    def mock_ctcss_info(bb):
+        return [100.0]
+
+    rx = receiver_factory(
+        source_file=str(iq_file),
+        sample_rate=1_000_000,
+        num_demod=1,
+        type_demod=0,  # NBFM
+        min_recording=0.2,
+        record=True,
+        file_metadata=["ctcss"],
+        get_ctcss_info=mock_ctcss_info
+    )
+
+    demod = rx.demodulators[0]
+    messages = []
+    async def custom_notify(msg):
+        if msg is not None:
+            messages.append(msg)
+    demod.notify_scanner = custom_notify
+
+    await demod.set_center_freq(30_000, 144_000_000)
+    rx.set_squelch(-50)
+
+    # Start flowgraph
+    rx.start()
+
+    # Sleep 1.0s to allow detection to match
+    await asyncio.sleep(1.0)
+    assert demod.is_ctcss_mismatched() == False
+    assert demod.ctcss_matched == True
+    assert demod.matched_ctcss_tone == 100.0
+
+    # Detune to trigger file save
+    await demod.set_center_freq(0, 144_000_000)
+
+    # Wait for completion
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, rx.wait)
+
+    # Check that message contains matched_ctcss
+    xmit_msg = next((m for m in messages if m.state == 'off'), None)
+    assert xmit_msg is not None
+    assert xmit_msg.matched_ctcss == 100.0
+
+    # Verify file saved has the CTCSS metadata suffix
+    wav_files = glob.glob(os.path.join(rx._wav_dir, "*.wav"))
+    assert len(wav_files) == 1
+    filename = os.path.basename(wav_files[0])
+    assert "_100.0Hz_" in filename
+
+
+@pytest.mark.asyncio
+async def test_max_ctcss_tones_configurable(receiver_factory, tmp_path, monkeypatch):
+    """
+    Test that the max_ctcss_tones parameter configured on Receiver is passed to BaseTuner
+    and limits the number of tones evaluated.
+    """
+    # Create a dummy IQ file to satisfy file source initialization
+    dummy_file = tmp_path / "dummy.iq"
+    dummy_file.write_bytes(b'\x00' * 8000)
+
+    # Create a receiver with max_ctcss_tones = 1
+    def mock_ctcss_info(bb):
+        return [100.0, 141.3]
+
+    rx = receiver_factory(
+        source_file=str(dummy_file),
+        sample_rate=1_000_000,
+        num_demod=1,
+        type_demod=0,
+        min_recording=0.2,
+        record=True,
+        get_ctcss_info=mock_ctcss_info,
+        max_ctcss_tones=1
+    )
+
+    demod = rx.demodulators[0]
+    assert demod.max_ctcss_tones == 1
+    assert len(demod._ctcss_squelches) == 1
+
+    # Tune frequency to apply config
+    await demod.set_center_freq(30_000, 144_000_000)
+    assert demod._active_tone_count == 1
+    assert demod._active_tones == [100.0]  # Second tone ignored
 


### PR DESCRIPTION
### Description
Adds support for monitoring multiple CTCSS (Continuous Tone-Coded Squelch System) tones on a single frequency or frequency range, allowing the receiver to unmute and record transmissions matching any of the configured tones.

### Key Changes

* **Multi-Tone Configurations**: Enables merging duplicate config entries (either exact matching single frequencies or exact matching frequency ranges) that differ only by their CTCSS tone. Different labels can be defined for each tone.
* **Parallel CTCSS Chains**: Updates the demodulator (`BaseTuner`) to run up to `max_ctcss_tones` parallel tone filtering and detection blocks (Goertzel filters) dynamically. 
* **Customizable Limits**: Adds a `--max-ctcss-tones` command-line argument (defaulting to 3) to configure the maximum supported parallel CTCSS tone chains per frequency/range.
* **Channel Logger Integration**: Updates the `FixedField` logger in [channel_loggers.py](file:///library/pub/dev/ham2mon/apps/channel_loggers.py) to write the matched CTCSS frequency (formatted to one decimal place) into the logging output.
* **GUI & Metadata Updates**:
  * Displays the matched/active CTCSS tone dynamically in the **CHANNELS** Curses window list.
  * Adds a `ctcss` option to `--file-metadata` to optionally append the matched CTCSS tone (e.g. `_100.0Hz`) to saved WAV filenames.
* **Testing**: Adds comprehensive unit and integration tests covering the multi-tone frequency manager merge logic, parallel Goertzel filter/squelch paths, `FixedField` channel loggers, Curses UI updates, and file metadata generation.

### Testing

Although there are  unit test cases for multi-tone support, it has only been tested with an FRS radio.  Much more testing is needed.