### PR TITLE
Refactor logging: isolate standard loggers and merge channel debug activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ usage: ham2mon.py [-h] [-a HW_ARGS] [-n NUM_DEMOD] [-d TYPE_DEMOD]
                   [--lb_gain LB_GAIN_DB] [-x MIX_GAIN_DB] [--agc]
                   [-s SQUELCH_DB] [-v VOLUME_DB] [-t THRESHOLD_DB] [-w]
                   [-F FREQUENCY_FILE_NAME] [--disable-lockout]
-                  [--disable-priority] [-P] [-T CHANNEL_LOG_TYPE]
-                  [-L CHANNEL_LOG_TARGET] [-A CHANNEL_LOG_TIMEOUT]
+                  [--disable-priority] [-P] [-T ACTIVITY_TYPE]
+                  [-L ACTIVITY_DEST] [-A ACTIVITY_INTERVAL]
                   [-c FREQ_CORRECTION] [-m] [-b AUDIO_BPS] [-M MAX_DB]
                   [-N MIN_DB] [-B CHANNEL_SPACING]
                   [--min_recording MIN_RECORDING]
@@ -278,12 +278,12 @@ options:
   --disable-lockout     Disable locking out of channels
   --disable-priority    Disable prioritization of channels
   -P, --auto-priority   Automatically add voice channels as priority channels
-  -T, --log_type CHANNEL_LOG_TYPE
-                        Log file type for channel detection
-  -L, --log_target CHANNEL_LOG_TARGET
-                        Log file or endpoint for channel detection
-  -A, --log_active_timeout CHANNEL_LOG_TIMEOUT
-                        Timeout delay for active channel log entries
+  -T, --activity-type ACTIVITY_TYPE
+                        Log file type for channel activity detection
+  -L, --activity-dest ACTIVITY_DEST
+                        Log file or endpoint for channel activity detection
+  -A, --activity-interval ACTIVITY_INTERVAL
+                        Timeout delay for active channel activity log entries
   -c, --correction FREQ_CORRECTION
                         Frequency correction in ppm
   -m, --mute-audio      Mute audio from speaker (still allows recording)
@@ -505,16 +505,17 @@ Labels can be assigned to frequencies and frequency ranges in the frequency file
 
 Labels are enabled by default and currently cannot be disabled.
 
-## Channel Detection Log File
-Channel events can be written to file or other targets.  Events occur when channel activity is detected as well as for ongoing activity.
+## Channel Activity Log File
+Channel events can be written to a file or external targets. Events occur when channel activity is detected (on/off states) as well as periodically for ongoing activity.
 
-By default, no channel activity is recorded.  The type can be specified with `--log_type`.  Current types include `fixed-field`, `debug` and `json-server`.  The default type is `none`.
+By default, no channel activity is logged to external targets. The type can be specified with `--activity-type`. Current types include `fixed-field` and `json-server`. The default type is `none`.
 
-A type may support a target through the `--log_target` option.  In the case of types the write to a file the target will be a file name.  The default target is `channel-log`.
+A type may support a destination through the `--activity-dest` option. In the case of types that write to a file, the destination will be a file name. The default destination is `channel-log`.
 
-An activity log entry is written every 15 seconds (by default).  This can be changed with `--log_active_timeout`.  Set this to 0 to disable activity logging (channel on/off messages will still occur).
+An activity log entry is written every 15 seconds (by default) for active channels. This can be changed with `--activity-interval`. Set this to 0 to disable periodic activity logging (channel on/off messages will still occur).
 
-If `debug` is selected as logging type then channel events can be viewed when the `--log-level=debug` option is also selected on the command line.
+> [!NOTE]
+> Channel activity events are also automatically sent to standard application logs at the `DEBUG` level. This means you do not need to specify a separate channel logger to see activity events in your developer logs; simply configure `--log-level=debug`.
 
 See [json-server example](doc/json-server_example.md) for one way this can be used.
 
@@ -528,7 +529,11 @@ If the number of voice transmissions is less than the number of data/skip transm
 Auto priority currently requires audio classification so `--voice` will automatically be enabled if this option is selected.  Therefore, `--model` must also be specified when using auto priority.
 
 ## Logging
-Application logging events can be configured using the `--log-level` and `--log-dest` options. These are separate from channel logging events (-L option) and are intended for application debugging. By default, logging is disabled (`--log-dest=none`). If enabled with `--log-dest=file`, logs are written to `ham2mon.log` (or a custom path specified with `--log-file`).
+Application logging events can be configured using the `--log-level` and `--log-dest` options. By default, logging is disabled (`--log-dest=none`). If enabled with `--log-dest=file`, logs are written to `ham2mon.log` (or a custom path specified with `--log-file`).
+
+`ham2mon` uses standard Python logging set up under a parent `"ham2mon"` namespace with module-level loggers (e.g. `[ham2mon.apps.receiver]` or `[ham2mon.apps.scanner]`). This allows developers to easily trace the source area of log messages. Additionally:
+* When `--log-level=debug` is enabled, all channel detection messages (e.g. tuning on, tuning off, periodic active updates) are automatically outputted to the standard logs.
+* Third-party dependency logs (such as `urllib3` or `gnuradio`) are isolated so they do not pollute the debug output files or standard streams.
 
 ## Audio Classification
 *Note: The classification is not 100% accurate.  There will be both false positives and negatives.*

--- a/apps/center_frequency_provider.py
+++ b/apps/center_frequency_provider.py
@@ -11,6 +11,8 @@ import logging
 import asyncio
 import typing
 
+logger = logging.getLogger(f"ham2mon.{__name__}")
+
 @dataclass(kw_only=True)
 class FrequencyRangeParams:
     '''
@@ -55,7 +57,7 @@ class FrequencyProvider():
     '''
   
     def __init__(self, params: FrequencyGroup) -> None:
-        logging.debug('Creating frequency provider')
+        logger.debug('Creating frequency provider')
 
         self.center_freq: int
         self.step: int = 0
@@ -98,7 +100,7 @@ class FrequencyProvider():
         This routine may be cancelled if the provider is informed
         of activity that should stop the advance to the next step.
         '''
-        logging.debug(f'starting: {self.step=} {self.center_freq=}')
+        logger.debug(f'starting: {self.step=} {self.center_freq=}')
 
         await asyncio.sleep(timeout)
 
@@ -124,16 +126,16 @@ class FrequencyProvider():
         if self.not_stepping():
             return
 
-        logging.debug('Got something of note, setting the active timer')
+        logger.debug('Got something of note, setting the active timer')
 
         was_cancelled = self.step_task.cancel()
         try:
             await self.step_task
         except asyncio.CancelledError: # This exception reflects that the coroutine addressed to the cancel
-            logging.debug("cancelled step task in frequency_provider")
+            logger.debug("cancelled step task in frequency_provider")
 
         if not was_cancelled:
-            logging.error('Could not cancel logging task in frequency_provider')
+            logger.error('Could not cancel logging task in frequency_provider')
 
         timeout = self.params.active_timeout
         self.step_task = asyncio.create_task(self.step_if_no_activity(timeout))
@@ -172,7 +174,7 @@ class FrequencyProvider():
 
             distance = int((end_at - start_at) / (number_of_moves - 1))
 
-            logging.debug(f'Range: {start_at}-{end_at} Steps: {number_of_moves} Distance: {distance}, Min time: {number_of_moves*self.params.quiet_timeout}')
+            logger.debug(f'Range: {start_at}-{end_at} Steps: {number_of_moves} Distance: {distance}, Min time: {number_of_moves*self.params.quiet_timeout}')
 
             center = start_at
             for _ in range(number_of_moves):

--- a/apps/channel_loggers.py
+++ b/apps/channel_loggers.py
@@ -8,25 +8,30 @@ from abc import ABC
 from dataclasses import dataclass, asdict
 from importlib import import_module
 import asyncio
+from typing import Callable
+
+logger = logging.getLogger(f"ham2mon.{__name__}")
 
 @dataclass(kw_only=True)
-class ChannelLogParams:
+class ActivityParams:
     '''
-    Holds channel log command line options provided by the user
+    Holds channel activity logging command line options provided by the user
     '''
     type: str
-    target: str
-    timeout: int
+    dest: str
+    interval: int
 
-class ChannelLogger(ABC):
+class ActivityLogger(ABC):
     '''
     Base class for all loggers.  Also notify scanner of activity.
     '''
-    def __init__(self, params: ChannelLogParams) -> None:
-        logging.debug(f'Creating {self.__class__.__name__} channel logger')
-        self.timeout: int = 0  # overridden by child classes
+    def __init__(self, params: ActivityParams,
+                 get_ctcss: Callable[[int], float | None] | None = None) -> None:
+        logger.debug(f'Creating {self.__class__.__name__} channel logger')
+        self.interval: int = 0  # overridden by child classes
         self.log_task: dict[int, asyncio.Task] = {}  # activity logging tasks are channel specific
         self.params = params
+        self.get_ctcss = get_ctcss  # optional callback: bb_freq -> matched ctcss tone or None
 
     async def log(self, msg: ChannelMessage | None) -> None:
         '''
@@ -39,70 +44,70 @@ class ChannelLogger(ABC):
             return
 
     @staticmethod
-    def get_logger(params: ChannelLogParams) -> 'ChannelLogger':
+    def get_logger(params: ActivityParams,
+                   get_ctcss: Callable[[int], float | None] | None = None) -> 'ActivityLogger':
         '''
         Factory to generate a class instance based on command line options
         '''
         if params.type == 'fixed-field':
-            return FixedField(params)
+            return FixedField(params, get_ctcss=get_ctcss)
         elif params.type == 'json-server':
-            return JsonToServer(params)
-        elif params.type == 'debug':
-            return Debug(params)
+            return JsonToServer(params, get_ctcss=get_ctcss)
         else:
-            return NoOp(params)
+            return NoOp(params, get_ctcss=get_ctcss)
 
     def handle_channel_state(self, msg: ChannelMessage) -> None:
         '''
         Use on/off events to start/stop activity timer
         '''
-        if self.timeout == 0:
+        if self.interval == 0:
             return
 
         channel = msg.channel
         if msg.state == 'on':
+            # Cancel any orphaned task for this channel before starting a new one
+            existing = self.log_task.get(channel)
+            if existing and not existing.done():
+                existing.cancel()
             # start reoccurring task to log that channel is active
             self.log_task[channel] = asyncio.create_task(self.log_active(msg))
         elif msg.state == 'off':
             # stop the reoccurring task
-            if self.log_task[channel]:
-                was_cancelled = self.log_task[channel].cancel()
+            task = self.log_task.get(channel)
+            if task:
+                was_cancelled = task.cancel()
                 if not was_cancelled:
-                    logging.error('Could not cancel logging task')
+                    logger.error('Could not cancel logging task')
+                try:
+                    del self.log_task[channel]
+                except KeyError:
+                    pass
 
     async def log_active(self, msg: ChannelMessage) -> None:
         '''
-        While the channel is active log at an interval
+        While the channel is active log at an interval.
+        Reads matched_ctcss live from the demodulator via the get_ctcss
+        callback (if provided) so heartbeats reflect the settled tone rather
+        than the None that was present at channel-open time.
         '''
         while True:
-            await asyncio.sleep(self.timeout)
+            await asyncio.sleep(self.interval)
+            live_ctcss = self.get_ctcss(msg.bb) if self.get_ctcss is not None else None
             await self.log(ChannelMessage(state='act',
                                     rf=msg.rf,
-                                    channel=msg.channel))
+                                    bb=msg.bb,
+                                    channel=msg.channel,
+                                    matched_ctcss=live_ctcss))
 
-class NoOp(ChannelLogger):
+class NoOp(ActivityLogger):
     '''
     Logger that ignores all events
     '''
-    def __init__(self, params: ChannelLogParams) -> None:
-        super().__init__(params)
+    def __init__(self, params: ActivityParams,
+                 get_ctcss: Callable[[int], float | None] | None = None) -> None:
+        super().__init__(params, get_ctcss=get_ctcss)
 
-        self.timeout: int = 0
-
-    async def log(self, msg: ChannelMessage | None) -> None:
-        if msg is None:
-            return
-
-        await super().log(msg)
-
-class Debug(ChannelLogger):
-    '''
-    Send channel events to the debug log (enable with --debug)
-    '''
-    def __init__(self, params: ChannelLogParams) -> None:
-        super().__init__(params)
-
-        self.timeout = params.timeout
+        self.interval: int = 0
 
     async def log(self, msg: ChannelMessage | None) -> None:
         if msg is None:
@@ -110,20 +115,16 @@ class Debug(ChannelLogger):
 
         await super().log(msg)
 
-        # for this logger we just write to the debug log
-        logging.debug(msg)
-
-        self.handle_channel_state(msg)
-
-class FixedField(ChannelLogger):
+class FixedField(ActivityLogger):
     '''
     Send channel events to a file with fixed field length records
     '''
-    def __init__(self, params) -> None:
-        super().__init__(params)
+    def __init__(self, params,
+                 get_ctcss: Callable[[int], float | None] | None = None) -> None:
+        super().__init__(params, get_ctcss=get_ctcss)
 
-        self.file_name = params.target
-        self.timeout = params.timeout
+        self.file_name = params.dest
+        self.interval = params.interval
 
     async def log(self, msg: ChannelMessage | None) -> None:
         if msg is None:
@@ -143,20 +144,19 @@ class FixedField(ChannelLogger):
 
         self.handle_channel_state(msg)
 
-class JsonToServer(ChannelLogger):
+class JsonToServer(ActivityLogger):
     '''
     Send channels events as json messages to  a remote server
     '''
-    def __init__(self, params) -> None:
-        super().__init__(params)
+    def __init__(self, params,
+                 get_ctcss: Callable[[int], float | None] | None = None) -> None:
+        super().__init__(params, get_ctcss=get_ctcss)
 
-        self.server = params.target
-        self.timeout = params.timeout
+        self.server = params.dest
+        self.interval = params.interval
 
         self.requests = import_module('requests')
-        # urllib3 is very chatty.  Uncomment is log event for every connection is needed.
-        # remove this if there is a single connection approach
-        logging.getLogger("urllib3").setLevel(logging.WARNING)
+        # urllib3 log suppression is configured at application startup in ham2mon.py
 
     async def log(self, msg: ChannelMessage | None) -> None:
         if msg is None:
@@ -165,19 +165,19 @@ class JsonToServer(ChannelLogger):
         await super().log(msg)
 
         msg_dict = asdict(msg)
-        logging.debug(f'{msg =}')
+        logger.debug(f'{msg =}')
 
         try:
             # TODO: open the connection once
             request = self.requests.post(self.server, json=msg_dict)
             request.raise_for_status()
         except self.requests.exceptions.HTTPError as errh:
-            logging.error(f'HTTP Error: {errh.args[0]}')
+            logger.error(f'HTTP Error: {errh.args[0]}')
         except self.requests.exceptions.ConnectionError as errc:
-            logging.error(f'Connection Error: {errc.args[0]}')
+            logger.error(f'Connection Error: {errc.args[0]}')
         except self.requests.exceptions.Timeout as errt:
-            logging.error(f'Timeout Error: {errt.args[0]}')
+            logger.error(f'Timeout Error: {errt.args[0]}')
         except self.requests.exceptions.RequestException as err:
-            logging.error(f'Some kind of Error: {err.args[0]}')
+            logger.error(f'Some kind of Error: {err.args[0]}')
 
         self.handle_channel_state(msg)

--- a/apps/classification.py
+++ b/apps/classification.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import Dict, Literal, Optional
 from dataclasses import dataclass
 
+logger = logging.getLogger(f"ham2mon.{__name__}")
+
 @dataclass(kw_only=True)
 class ClassifierParams:
     '''
@@ -60,7 +62,7 @@ class Classifier(object):
         script_dir = Path(__file__).parent
         service_script = script_dir / "classification_service.py"
 
-        logging.info("Starting background TensorFlow classification service subprocess...")
+        logger.info("Starting background TensorFlow classification service subprocess...")
 
         # bufsize=1 ensures line-buffering so that readline and write lines flush immediately.
         self._proc = subprocess.Popen(
@@ -125,24 +127,24 @@ class Classifier(object):
                     stripped = line.strip()
                     if stripped:
                         if stripped.startswith("INFO:"):
-                            logging.info(f"TensorFlow Service: {stripped}")
+                            logger.info(f"TensorFlow Service: {stripped}")
                         else:
-                            logging.warning(f"TensorFlow Service: {stripped}")
+                            logger.warning(f"TensorFlow Service: {stripped}")
             except Exception as e:
                 try:
-                    logging.debug(f"TensorFlow Service stderr drain thread exception: {e}")
+                    logger.debug(f"TensorFlow Service stderr drain thread exception: {e}")
                 except Exception:
                     pass
             finally:
                 try:
-                    logging.debug("TensorFlow Service stderr drain thread exiting.")
+                    logger.debug("TensorFlow Service stderr drain thread exiting.")
                 except Exception:
                     pass
 
         t = threading.Thread(target=log_stderr_stream, args=(self._proc.stderr,), daemon=True)
         t.start()
 
-        logging.info("TensorFlow classification service started successfully!")
+        logger.info("TensorFlow classification service started successfully!")
         self._loaded = True
 
     def is_wanted(self, file: str) -> tuple[bool, Optional[Literal['V', 'D', 'S']]]:
@@ -151,12 +153,12 @@ class Classifier(object):
                 or self._proc.poll() is not None
                 or self._proc.stdin is None
                 or self._proc.stdout is None):
-            logging.warning("TensorFlow classification service is not running. Attempting restart...")
+            logger.warning("TensorFlow classification service is not running. Attempting restart...")
             self.clean_up()
             try:
                 self._ensure_loaded()
             except Exception as e:
-                logging.error(f"Failed to restart TensorFlow classification service: {e}")
+                logger.error(f"Failed to restart TensorFlow classification service: {e}")
                 return False, None
 
         if (self._proc is None
@@ -172,8 +174,8 @@ class Classifier(object):
         # Read prediction response from process stdout with a timeout to avoid hangs
         ready_r, _, _ = select.select([self._proc.stdout], [], [], 5.0)
         if not ready_r:
-            logging.error(f"Timeout waiting for classification response for file: {file}")
-            logging.warning(f"Classification result lost for {file} due to subprocess hang.")
+            logger.error(f"Timeout waiting for classification response for file: {file}")
+            logger.warning(f"Classification result lost for {file} due to subprocess hang.")
             self.clean_up()  # Terminate hung subprocess
             return False, None
 
@@ -196,11 +198,11 @@ class Classifier(object):
             try:
                 self._proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                logging.warning("Classification service did not terminate in time. Killing it...")
+                logger.warning("Classification service did not terminate in time. Killing it...")
                 self._proc.kill()
                 self._proc.wait()
         except Exception as e:
-            logging.debug(f"Error during classification service cleanup: {e}")
+            logger.debug(f"Error during classification service cleanup: {e}")
         finally:
             self._proc = None
             self._loaded = False

--- a/apps/cursesgui.py
+++ b/apps/cursesgui.py
@@ -13,6 +13,8 @@ import logging
 from pathlib import PurePath
 from frequency_manager import ConfigFrequency, ChannelFrequency, ChannelList, FrequencyList
 
+logger = logging.getLogger(f"ham2mon.{__name__}")
+
 locale.setlocale(locale.LC_ALL, '')
 
 
@@ -667,8 +669,8 @@ class RxWindow(object):
         type_demod (int): Type of demodulation (0 = FM, 1 = AM)
         record (bool): Record audio to file if True
         frequency_file_name (PurePath): Name of file with frequencies
-        channel_log_file_name (string): Name of file for channel activity logging
-        channel_log_timeout (int): Timeout delay between logging active state of channel in seconds
+        activity_dest (string): Name of file or endpoint for channel activity logging
+        activity_interval (int): Timeout delay between logging active state of channel in seconds
         log_mode (string): Log system mode (file, database type)
     """
     # pylint: disable=too-many-instance-attributes
@@ -688,8 +690,8 @@ class RxWindow(object):
         self.type_demod = 0
         self.record = True
         self.frequency_file_name: PurePath = None
-        self.channel_log_type = ""
-        self.channel_log_target = ""
+        self.activity_type = ""
+        self.activity_dest = ""
         self.gains = None
         self.classifier_params = None
 
@@ -822,7 +824,7 @@ class RxWindow(object):
         # drop column-2 values (max_len clamps to 0) without this notice.
         min_two_col_width = RxWindow.RxEntry.column_width * 2
         if self.dims[1] < min_two_col_width:
-            logging.warning(
+            logger.warning(
                 "RxWindow inner width %d < %d; column-2 fields will not be drawn",
                 self.dims[1], min_two_col_width)
 
@@ -865,12 +867,12 @@ class RxWindow(object):
         self.frequency_file_name_field = RxWindow.RxEntry(
             "Freq File", 2, 'left', False)
 
-        self.channel_log_type_field = RxWindow.RxEntry(
-            "Log Type", 2, 'left', False)
+        self.activity_type_field = RxWindow.RxEntry(
+            "Activity Type", 2, 'left', False)
 
-        if self.channel_log_target is not None:
-            self.channel_log_target_field = RxWindow.RxEntry(
-                "Log Target", 2, 'left', False)
+        if self.activity_dest is not None:
+            self.activity_dest_field = RxWindow.RxEntry(
+                "Activity Dest", 2, 'left', False)
 
     def draw_rx(self) -> None:
         """Draws receiver parameters
@@ -915,10 +917,10 @@ class RxWindow(object):
         file_name = self.frequency_file_name.name if self.frequency_file_name else "none"
         self.frequency_file_name_field.set(file_name)
 
-        self.channel_log_type_field.set(self.channel_log_type)
+        self.activity_type_field.set(self.activity_type)
 
-        if self.channel_log_target is not None:
-            self.channel_log_target_field.set(self.channel_log_target)
+        if self.activity_dest is not None:
+            self.activity_dest_field.set(self.activity_dest)
 
         # Hide cursor
         self.win.leaveok(1)

--- a/apps/demodulators/BaseTuner.py
+++ b/apps/demodulators/BaseTuner.py
@@ -21,6 +21,8 @@ from frequency_manager import ChannelMessage
 from utilities import baseband_to_frequency
 from classification import Classifier
 
+logger = logging.getLogger(f"ham2mon.{__name__}")
+
 class BaseTuner(gr.hier_block2):
     """Some base methods that are the same between the known tuner types.
 
@@ -132,7 +134,7 @@ class BaseTuner(gr.hier_block2):
 
     def set_last_heard(self, a_time: float) -> None:
         self.last_heard = a_time
-        # channel_log active channel if at required interval
+        # Log active channel if at required interval
         # alternately use a timer or something that is created on demod start
 
     async def set_center_freq(self, center_freq: int, rf_center_freq: int, avg_signal: int | None = None) -> None:
@@ -157,16 +159,17 @@ class BaseTuner(gr.hier_block2):
                 self.discard_current = True
             # Move file from tmp directory if it is long enough
             # and classified appropriately
-            results = self._persist_wavfile(rf_center_freq, avg_signal=avg_signal)   # also get channel_log information
+            results = self._persist_wavfile(rf_center_freq, avg_signal=avg_signal)   # also get activity logging information
         else:
             self.discard_current = False
             if self.center_freq != 0:
                 # not recording files and center_freq has changed
                 results = ChannelMessage(state='off',
-                                         rf=baseband_to_frequency(
-                                            self.center_freq, rf_center_freq),
-                                         bb=self.center_freq,
-                                         channel=self.channel)
+                                         rf=float(baseband_to_frequency(
+                                            self.center_freq, rf_center_freq)),
+                                         bb=int(self.center_freq),
+                                         channel=int(self.channel),
+                                         matched_ctcss=float(self.matched_ctcss_tone) if self.matched_ctcss_tone is not None else None)
             else:
                 # center_freq is 0
                 results = None
@@ -199,15 +202,15 @@ class BaseTuner(gr.hier_block2):
                 try:
                     self._rec_selector.set_output_index(1)
                 except IndexError as e:
-                    logging.warning("Failed to set recording selector index: %s", e)
+                    logger.warning("Failed to set recording selector index: %s", e)
 
 
         if self.center_freq != 0:
             await self.notify_scanner(ChannelMessage(state='on',
-                                                         rf=baseband_to_frequency(
-                                                            self.center_freq, rf_center_freq),
-                                                         bb=self.center_freq,
-                                                         channel=self.channel))
+                                                         rf=float(baseband_to_frequency(
+                                                            self.center_freq, rf_center_freq)),
+                                                         bb=int(self.center_freq),
+                                                         channel=int(self.channel)))
 
     def set_file_name(self, rf_center_freq: int) -> None:
         self.tstamp_str = time.strftime("%Y%m%d_%H%M%S", time.localtime()) + "{:.3f}".format(self.time_stamp % 1)[1:]
@@ -238,16 +241,16 @@ class BaseTuner(gr.hier_block2):
             try:
                 self._rec_selector.set_output_index(0)
             except IndexError as e:
-                logging.warning("Failed to set recording selector index: %s", e)
+                logger.warning("Failed to set recording selector index: %s", e)
 
         self.blocks_wavfile_sink.close()
 
         xmit_msg = ChannelMessage(state='off',
-                                rf=baseband_to_frequency(self.center_freq, rf_center_freq),
-                                bb=self.center_freq,
-                                channel=self.channel,
-                                signal_db=avg_signal,
-                                matched_ctcss=self.matched_ctcss_tone)
+                                rf=float(baseband_to_frequency(self.center_freq, rf_center_freq)),
+                                bb=int(self.center_freq),
+                                channel=int(self.channel),
+                                signal_db=int(avg_signal) if avg_signal is not None else None,
+                                matched_ctcss=float(self.matched_ctcss_tone) if self.matched_ctcss_tone is not None else None)
 
         # Discard the file if flagged as mismatched CTCSS
         if self.discard_current:
@@ -256,7 +259,7 @@ class BaseTuner(gr.hier_block2):
                 try:
                     os.unlink(self.file_name)
                 except OSError as e:
-                    logging.warning("Failed to delete mismatched CTCSS file %s: %s", self.file_name, e)
+                    logger.warning("Failed to delete mismatched CTCSS file %s: %s", self.file_name, e)
             xmit_msg.detail = 'Discarded mismatched CTCSS'
             return xmit_msg
 
@@ -265,7 +268,7 @@ class BaseTuner(gr.hier_block2):
             try:
                 os.unlink(self.file_name)
             except OSError as e:
-                logging.warning("Failed to delete short recording file %s: %s", self.file_name, e)
+                logger.warning("Failed to delete short recording file %s: %s", self.file_name, e)
             xmit_msg.detail = 'Discarded short recording'
             return xmit_msg
 
@@ -278,7 +281,7 @@ class BaseTuner(gr.hier_block2):
                 try:
                     os.unlink(self.file_name)
                 except OSError as e:
-                    logging.warning("Failed to delete unwanted classification file %s: %s", self.file_name, e)
+                    logger.warning("Failed to delete unwanted classification file %s: %s", self.file_name, e)
                 xmit_msg.detail = 'Discarded unwanted classification'
                 return xmit_msg
 
@@ -376,7 +379,7 @@ class BaseTuner(gr.hier_block2):
             try:
                 self._rec_selector.set_output_index(1 if self.file_name is not None else 0)
             except IndexError as e:
-                logging.warning("Failed to configure recording selector: %s", e)
+                logger.warning("Failed to configure recording selector: %s", e)
 
     def _apply_ctcss_config(self, ctcss_tones: list[float] | None) -> None:
         """Applies CTCSS configuration parameters and updates routing if started.
@@ -390,7 +393,7 @@ class BaseTuner(gr.hier_block2):
         tones = list(ctcss_tones) if ctcss_tones else []
 
         if len(tones) > self.max_ctcss_tones:
-            logging.warning(
+            logger.warning(
                 f"Channel {self.channel}: {len(tones)} CTCSS tones configured but "
                 f"only {self.max_ctcss_tones} are supported; the rest will be ignored")
             tones = tones[:self.max_ctcss_tones]

--- a/apps/frequency_manager.py
+++ b/apps/frequency_manager.py
@@ -12,6 +12,8 @@ import yaml
 import logging
 from utilities import frequency_to_baseband
 
+logger = logging.getLogger(f"ham2mon.{__name__}")
+
 
 @dataclass(kw_only=True)
 class FrequencyInfo:
@@ -257,16 +259,16 @@ class FrequencyManager:
         if not file.exists():
             raise FileNotFoundError(f'Frequency file does not exist: {file}')
 
-        logging.debug(f'Loading frequencies from {file}')
+        logger.debug(f'Loading frequencies from {file}')
         with file.open(mode='r') as file:
             try:
                 frequencies_config = yaml.safe_load(file)
             except yaml.YAMLError as e:
                 if hasattr(e, 'problem_mark'):
-                    logging.error(
+                    logger.error(
                         f'{e.problem_mark} {e.problem} {e.context if e.context else ""}')
                 else:
-                    logging.error(
+                    logger.error(
                         f'Something went wrong while parsing yaml file: {file}')
                 raise Exception(
                     "Invalid yaml frequency file (enable debugging for more info)")
@@ -371,7 +373,7 @@ class FrequencyManager:
 
         existing.ctcss_tones.append(wanted.ctcss)
         existing.ctcss_labels.append(wanted.label or existing.label or "")
-        logging.debug(
+        logger.debug(
             f'Merged CTCSS tone {wanted.ctcss} into existing frequency '
             f'{existing.label!r} (tones now {existing.ctcss_tones})')
 

--- a/apps/h2m_parser.py
+++ b/apps/h2m_parser.py
@@ -9,7 +9,7 @@ Created on Sat Jul 18 15:21:33 2015
 # from optparse import OptionParser
 from argparse import ArgumentParser
 from pathlib import Path
-from channel_loggers import ChannelLogParams
+from channel_loggers import ActivityParams
 from classification import ClassifierParams
 from center_frequency_provider import FrequencyRangeParams, FrequencySingleParams, FrequencyGroup
 from frequency_manager import FrequencyConfiguration
@@ -32,9 +32,9 @@ class CLParser(object):
         disable_lockout (bool): Disable locking out of channels
         disable_priority (bool): Disable prioritization out of channels
         auto_priority (bool): Automatically set priority channels
-        channel_log_target (string): Name of file or endpoint for channel logging
-        channel_log_type (string): Log file type for channel detection
-        channel_log_timeout (int): Timeout delay between active channel log entries
+        activity_dest (string): Name of file or endpoint for channel activity logging
+        activity_type (string): Log file type for channel activity detection
+        activity_interval (int): Timeout delay between active channel activity log entries
         freq_correction (int): Frequency correction in ppm
         audio_bps (int): Audio bit depth in bps
         max_db (float): Spectrum max dB for display
@@ -146,20 +146,20 @@ class CLParser(object):
                           dest="auto_priority",
                           help="Automatically add voice channels as priority channels")
 
-        parser.add_argument("-T", "--log_type", type=str,
-                          dest="channel_log_type",
+        parser.add_argument("-T", "--activity-type", type=str,
+                          dest="activity_type",
                           default="none",
-                          help="Log file type for channel detection")
+                          help="Log file type for channel activity detection (none, fixed-field, json-server)")
 
-        parser.add_argument("-L", "--log_target", type=str,
-                          dest="channel_log_target",
+        parser.add_argument("-L", "--activity-dest", type=str,
+                          dest="activity_dest",
                           default="channel-log",
-                          help="Log file or endpoint for channel detection")
+                          help="Log file or endpoint for channel activity detection")
 
-        parser.add_argument("-A", "--log_active_timeout", type=int,
-                          dest="channel_log_timeout",
+        parser.add_argument("-A", "--activity-interval", type=int,
+                          dest="activity_interval",
                           default=15,
-                          help="Timeout delay for active channel log entries")
+                          help="Timeout delay for active channel activity log entries")
 
         parser.add_argument("-c", "--correction", type=int, dest="freq_correction",
                           default=0,
@@ -298,10 +298,10 @@ class CLParser(object):
             max_ctcss_tones=int(options.max_ctcss_tones)
         )
 
-        self.channel_log_params = ChannelLogParams(
-            target=str(options.channel_log_target),
-            type=str(options.channel_log_type),
-            timeout=int(options.channel_log_timeout)
+        self.activity_params = ActivityParams(
+            dest=str(options.activity_dest),
+            type=str(options.activity_type),
+            interval=int(options.activity_interval)
         )
         self.freq_correction = int(options.freq_correction)
         self.audio_bps = int(options.audio_bps)
@@ -375,9 +375,9 @@ def main():
     print("record:              " + str(parser.record))
     print("play:                " + str(parser.play))
     print("frequency_file_name: " + str(parser.frequency_configuration.file_name))
-    print("channel_log target:  " + str(parser.channel_log_params.target))
-    print("channel_log timeout: " + str(parser.channel_log_params.timeout))
-    print("channel_log type:    " + str(parser.channel_log_params.type))
+    print("activity_dest:       " + str(parser.activity_params.dest))
+    print("activity_interval:   " + str(parser.activity_params.interval))
+    print("activity_type:       " + str(parser.activity_params.type))
     print("freq_correction:     " + str(parser.freq_correction))
     print("audio_bps:           " + str(parser.audio_bps))
     print("max_db:              " + str(parser.max_db))

--- a/apps/ham2mon.py
+++ b/apps/ham2mon.py
@@ -21,6 +21,8 @@ from os.path import realpath, dirname
 
 import _curses
 
+logger = logging.getLogger("ham2mon")
+
 class MyDisplay():
 
     def __init__(self, stdscr: "_curses._CursesWindow") -> None:
@@ -102,13 +104,13 @@ class MyDisplay():
         self.rxwin.record = self.scanner.record
         self.rxwin.type_demod = PARSER.type_demod
         self.rxwin.frequency_file_name = self.scanner.frequency_file_name
-        self.rxwin.channel_log_type = self.scanner.channel_log_params.type
-        # not all channel_log types use a target
-        if self.scanner.channel_log_params.type == 'fixed-field':
-            target = self.scanner.channel_log_params.target
+        self.rxwin.activity_type = self.scanner.activity_params.type
+        # not all activity types use a dest
+        if self.scanner.activity_params.type == 'fixed-field':
+            dest = self.scanner.activity_params.dest
         else:
-            target = None
-        self.rxwin.channel_log_target = target
+            dest = None
+        self.rxwin.activity_dest = dest
 
         self.specwin.max_db = PARSER.max_db
         self.specwin.min_db = PARSER.min_db
@@ -153,7 +155,7 @@ class MyDisplay():
         record = PARSER.record
         play = PARSER.play
         frequency_configuration = PARSER.frequency_configuration
-        channel_log_params = PARSER.channel_log_params
+        activity_params = PARSER.activity_params
         freq_correction = PARSER.freq_correction
         audio_bps = PARSER.audio_bps
         channel_spacing = PARSER.channel_spacing
@@ -173,7 +175,7 @@ class MyDisplay():
 
         scanner = scnr.Scanner(ask_samp_rate, num_demod, type_demod, hw_args,
                                freq_correction, record, frequency_configuration,
-                               channel_log_params,
+                               activity_params,
                                play, audio_bps, channel_spacing,
                                frequency_params, min_recording, max_recording,
                                classifier_params, auto_priority, agc,
@@ -248,14 +250,14 @@ if __name__ == '__main__':
             }
             level = log_level_map.get(PARSER.log_level, logging.WARNING)
 
-            logger = logging.getLogger()
             logger.setLevel(level)
+            logger.propagate = False
 
-            formatter = logging.Formatter('%(asctime)s %(message)s')
+            formatter = logging.Formatter('%(asctime)s [%(name)s] %(levelname)s: %(message)s')
 
             if PARSER.log_dest == 'syslog':
                 syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
-                syslog_handler.setFormatter(logging.Formatter('ham2mon[%(process)d]: %(message)s'))
+                syslog_handler.setFormatter(logging.Formatter('ham2mon[%(process)d]: [%(name)s] %(levelname)s: %(message)s'))
                 logger.addHandler(syslog_handler)
             elif PARSER.log_dest == 'stderr':
                 stream_handler = logging.StreamHandler()
@@ -270,6 +272,9 @@ if __name__ == '__main__':
                 file_handler.setFormatter(formatter)
                 logger.addHandler(file_handler)
 
+            # Suppress chatty third-party loggers that would otherwise pollute output
+            logging.getLogger("urllib3").setLevel(logging.WARNING)
+
         wrapper(main)
     except KeyboardInterrupt:
         pass
@@ -278,7 +283,7 @@ if __name__ == '__main__':
         print("RuntimeError: SDR hardware not detected or insufficient USB permissions. Try running as root or with --log-level=debug option.")
         print("")
         print(f'RuntimeError: {error=}, {type(error)=}')
-        logging.debug(traceback.format_exc())
+        logger.debug(traceback.format_exc())
         print("")
     except err.LogError:
         print("")
@@ -287,5 +292,5 @@ if __name__ == '__main__':
     except OSError as error:
         print("")
         print(f'OS error: {error=}, {type(error)=}')
-        logging.debug(traceback.format_exc())
+        logger.debug(traceback.format_exc())
         print("")

--- a/apps/receiver.py
+++ b/apps/receiver.py
@@ -24,6 +24,8 @@ from demodulators.AM import TunerDemodAM
 from demodulators.WBFM import TunerDemodWBFM
 from classification import ClassificationNotWanted, Classifier, ClassifierParams
 
+logger = logging.getLogger(f"ham2mon.{__name__}")
+
 class Receiver(gr.top_block):
     """Receiver for NBFM and AM modulation
 
@@ -71,7 +73,7 @@ class Receiver(gr.top_block):
         try:
             os.makedirs(os.path.join(self._wav_dir, 'tmp'), exist_ok=True)
         except OSError as error:  # will need to add something here for Win support
-            logging.error(f"Could not create wav/tmp directory: {error}")
+            logger.error(f"Could not create wav/tmp directory: {error}")
             raise
 
         # Clean up existing files without breaking makedirs or masking permission errors
@@ -79,7 +81,7 @@ class Receiver(gr.top_block):
             try:
                 os.unlink(f)
             except OSError as error:
-                logging.warning(f"Could not remove stale wav file: {f} ({error})")
+                logger.warning(f"Could not remove stale wav file: {f} ({error})")
 
         # Default values
         self.center_freq: int = center_freq
@@ -152,7 +154,7 @@ class Receiver(gr.top_block):
             classifier = None
         except Exception as error:
             msg = f'Could not create classifier ({error})'
-            logging.error(msg)
+            logger.error(msg)
             raise Exception(msg)
 
         self.file_metadata = file_metadata if file_metadata is not None else []
@@ -220,7 +222,7 @@ class Receiver(gr.top_block):
                 # Connect the summed outputs to the audio sink
                 self.connect(add_ff, audio_sink)
             except RuntimeError as error:
-                logging.warning(f"Could not initialize audio sink (speaker output disabled): {error}")
+                logger.warning(f"Could not initialize audio sink (speaker output disabled): {error}")
                 # Fall back to null sink to prevent application crash
                 null_sink = blocks.null_sink(gr.sizeof_float)
                 self.connect(add_ff, null_sink)
@@ -242,7 +244,7 @@ class Receiver(gr.top_block):
                 assert agc == agc_is_set, f'set_gain_mode returned "{agc_is_set}"'
             except Exception as error:
                 msg = f'Could not set AGC mode ({error})'
-                logging.error(msg)
+                logger.error(msg)
                 raise Exception(msg)
 
         samp_rate = src.get_sample_rate()

--- a/apps/scanner.py
+++ b/apps/scanner.py
@@ -15,12 +15,14 @@ import threading
 # import yaml
 import logging
 from numpy.typing import NDArray
-from channel_loggers import ChannelLogParams, ChannelMessage, ChannelLogger
+from channel_loggers import ActivityParams, ChannelMessage, ActivityLogger
 from classification import ClassifierParams
 from center_frequency_provider import FrequencyGroup, FrequencyProvider
 from frequency_manager import FrequencyManager, FrequencyList, FrequencyConfiguration, ChannelFrequency, ChannelList
 from utilities import baseband_to_frequency, frequency_to_baseband
 from dataclasses import dataclass, field
+
+logger = logging.getLogger(f"ham2mon.{__name__}")
 
 @dataclass(kw_only=True)
 class ClassificationCount:
@@ -46,7 +48,7 @@ class Scanner(object):
         record (bool): Record audio to file if True
         auto_priority (bool): Automatically set priority channels
         frequency_configuration (FrequencyConfiguration): File name and other config information
-        channel_log_params (ChannelLogParams): Parameters for logging channel activity
+        activity_params (ActivityParams): Parameters for logging channel activity
         audio_bps (int): Audio bit depth in bps (bits/samples)
         frequency_params (FrequencyGroup): Parameters for frequency provider
         spacing (int): granularity of frequency quantization
@@ -74,7 +76,7 @@ class Scanner(object):
     def __init__(self, ask_samp_rate: int=int(4E6), num_demod: int=4, type_demod: int=0,
                  hw_args: str="uhd", freq_correction: int=0, record: bool=True,
                  frequency_configuration: FrequencyConfiguration | None=None,
-                 channel_log_params: ChannelLogParams=ChannelLogParams(type='none', target='', timeout=0),
+                 activity_params: ActivityParams=ActivityParams(type='none', dest='', interval=0),
                  play: bool=True,
                  audio_bps: int=8, channel_spacing: int=5000,
                  frequency_params: FrequencyGroup=FrequencyGroup(sample_rate=int(4E6)),
@@ -96,7 +98,7 @@ class Scanner(object):
         self.frequencies: FrequencyList = []    # needed for the UI
         self.channels: ChannelList = []
         self._channels: ChannelList = []
-        self.channel_log_params = channel_log_params
+        self.activity_params = activity_params
         self.channel_spacing = channel_spacing
         self.frequency_file_name = frequency_configuration.file_name  # used by the gui
         self.log_timeout_last = int(time.time())
@@ -109,7 +111,8 @@ class Scanner(object):
         self._demod_signal_stats: dict[int, tuple[float, int]] = {i: (0.0, 0) for i in range(num_demod)}
         self.mismatched_freqs: dict[float, float] = {}
 
-        self.channel_logger = ChannelLogger.get_logger(channel_log_params)
+        self.activity_logger = ActivityLogger.get_logger(activity_params,
+                                                        get_ctcss=self.get_matched_ctcss)
 
         self.frequency_manager = FrequencyManager(frequency_configuration, self.channel_spacing)
 
@@ -156,9 +159,9 @@ class Scanner(object):
     def _wait_for_receiver_thread(self) -> None:
         try:
             self.receiver.wait()
-            logging.info("Receiver flowgraph terminated (EOF reached)")
+            logger.info("Receiver flowgraph terminated (EOF reached)")
         except Exception as error:
-            logging.error(f"Error waiting for receiver: {error}")
+            logger.error(f"Error waiting for receiver: {error}")
         finally:
             self.eof = True
 
@@ -476,12 +479,24 @@ class Scanner(object):
 
         msg.priority = self.frequency_manager.is_priority(msg.bb)   # TODO: is_priority only takes base band frequency
 
-        await self.channel_logger.log(msg)  # off events or nothing to note
+        # NOTE: msg is a mutable dataclass reference. Log it before passing to activity_logger
+        # so that any in-place field mutation by a logger does not silently alter the debug record.
+        logger.debug(msg)
+
+        await self.activity_logger.log(msg)  # off events or nothing to note
 
         if self.interesting(msg):
             await self.frequency_provider.interesting_activity()
 
         await self.priority_assess(msg.rf, msg.classification)
+
+    def get_matched_ctcss(self, bb: int) -> float | None:
+        '''Return the live matched CTCSS tone for the demodulator currently
+        tuned to baseband frequency `bb`, or None if unknown/unmatched.
+        Used by the channel logger to populate act-heartbeat messages.
+        '''
+        d = self.receiver.get_demod_freq_map().get(bb)
+        return d.matched_ctcss_tone if d is not None else None
 
     def interesting(self, msg: ChannelMessage) -> bool:
         '''
@@ -525,11 +540,11 @@ class Scanner(object):
         metrics: ClassificationCount = self.xmit_stats[freq]
         if metrics.V > metrics.D and metrics.V > metrics.S:  # Flag voice frequency as priority if not already set
             if self.frequency_manager.is_priority(bb_freq) is None:
-                logging.debug(f'adding {freq=} to priority list')
+                logger.debug(f'adding {freq=} to priority list')
                 self.frequencies = await self.frequency_manager.change({'single': freq, 'priority': 1, 'mode': 'add'})
         else: # If not voice, remove from priority list if it currently a priority
             if self.frequency_manager.is_priority(bb_freq) is not None:
-                logging.debug(f'removing {freq=} from the priority list')
+                logger.debug(f'removing {freq=} from the priority list')
                 self.frequencies = await self.frequency_manager.change({'single': freq, 'priority': None, 'mode': 'add'})
 
     async def clean_up(self) -> None:
@@ -566,7 +581,7 @@ async def main() -> None:
     freq_correction = parser.freq_correction
     record = parser.record
     frequency_configuration = parser.frequency_configuration
-    channel_log_params = parser.channel_log_params
+    activity_params = parser.activity_params
     play = parser.play
     audio_bps = parser.audio_bps
     channel_spacing = parser.channel_spacing
@@ -576,7 +591,7 @@ async def main() -> None:
     classifier_params = parser.classifier_params
     scanner = Scanner(ask_samp_rate, num_demod, type_demod, hw_args,
                         freq_correction, record, frequency_configuration,
-                        channel_log_params, play,
+                        activity_params, play,
                         audio_bps, channel_spacing, frequency_params,
                         min_recording, max_recording,
                         classifier_params)

--- a/apps/tests/test_channel_loggers.py
+++ b/apps/tests/test_channel_loggers.py
@@ -1,12 +1,13 @@
 import pytest
+import asyncio
 from unittest.mock import MagicMock
-from channel_loggers import ChannelLogParams, FixedField, JsonToServer
+from channel_loggers import ActivityParams, FixedField, JsonToServer, ActivityLogger, NoOp
 from frequency_manager import ChannelMessage
 
 @pytest.mark.asyncio
 async def test_fixed_field_logger(tmp_path):
     log_file = tmp_path / "channel.log"
-    params = ChannelLogParams(type="fixed-field", target=str(log_file), timeout=0)
+    params = ActivityParams(type="fixed-field", dest=str(log_file), interval=0)
     logger = FixedField(params)
 
     # 1. Message WITH matched CTCSS
@@ -56,7 +57,7 @@ async def test_fixed_field_logger(tmp_path):
 
 @pytest.mark.asyncio
 async def test_json_to_server_logger():
-    params = ChannelLogParams(type="json-server", target="http://example.com/log", timeout=0)
+    params = ActivityParams(type="json-server", dest="http://example.com/log", interval=0)
     logger = JsonToServer(params)
 
     # Mock requests post directly on the instance's requests object
@@ -85,3 +86,91 @@ async def test_json_to_server_logger():
     assert posted_json["state"] == "on"
     assert posted_json["rf"] == 145.5
     assert posted_json["file"] == "test.wav"
+
+
+class SpyLogger(ActivityLogger):
+    def __init__(self, params: ActivityParams, get_ctcss=None) -> None:
+        super().__init__(params, get_ctcss=get_ctcss)
+        self.interval = params.interval
+        self.logged_messages = []
+
+    async def log(self, msg: ChannelMessage | None) -> None:
+        if msg is None:
+            return
+        await super().log(msg)
+        self.logged_messages.append(msg)
+        self.handle_channel_state(msg)
+
+
+def test_activity_logger_factory():
+    # 1. fixed-field logger
+    params_ff = ActivityParams(type="fixed-field", dest="file.log", interval=0)
+    assert isinstance(ActivityLogger.get_logger(params_ff), FixedField)
+
+    # 2. json-server logger
+    params_js = ActivityParams(type="json-server", dest="http://example.com", interval=0)
+    assert isinstance(ActivityLogger.get_logger(params_js), JsonToServer)
+
+    # 3. debug (which is now removed/unsupported) -> falls back to NoOp
+    params_debug = ActivityParams(type="debug", dest="", interval=0)
+    assert isinstance(ActivityLogger.get_logger(params_debug), NoOp)
+
+    # 4. none -> NoOp
+    params_none = ActivityParams(type="none", dest="", interval=0)
+    assert isinstance(ActivityLogger.get_logger(params_none), NoOp)
+
+
+@pytest.mark.asyncio
+async def test_channel_state_handling_keyerror_and_leak_prevention():
+    params = ActivityParams(type="test", dest="", interval=5)
+    logger = SpyLogger(params)
+
+    # 1. Sending an 'off' message without an 'on' message first (no active task)
+    # This should not raise a KeyError.
+    msg_off = ChannelMessage(state="off", rf=145.5, bb=0, channel=1)
+    await logger.log(msg_off)
+    assert 1 not in logger.log_task
+
+    # 2. Sending an 'on' message should start a task
+    msg_on = ChannelMessage(state="on", rf=145.5, bb=0, channel=2)
+    await logger.log(msg_on)
+    assert 2 in logger.log_task
+    task = logger.log_task[2]
+    assert not task.done()
+
+    # 3. Sending an 'off' message should cancel the task and delete it from dict
+    msg_off_2 = ChannelMessage(state="off", rf=145.5, bb=0, channel=2)
+    await logger.log(msg_off_2)
+    assert 2 not in logger.log_task
+    # Yield control to let cancellation take effect in the event loop
+    await asyncio.sleep(0)
+    assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_channel_state_active_logging():
+    # Set a very low timeout (10ms) for testing
+    params = ActivityParams(type="test", dest="", interval=0.01)
+    mock_get_ctcss = MagicMock(return_value=100.0)
+    logger = SpyLogger(params, get_ctcss=mock_get_ctcss)
+
+    # Send 'on' message to start active logging
+    msg_on = ChannelMessage(state="on", rf=145.5, bb=0, channel=3)
+    await logger.log(msg_on)
+
+    # Wait long enough for at least 2 active logging ticks to occur
+    await asyncio.sleep(0.035)
+
+    # Send 'off' message to terminate active logging
+    msg_off = ChannelMessage(state="off", rf=145.5, bb=0, channel=3)
+    await logger.log(msg_off)
+
+    # Verify that 'act' (active) messages were logged periodically
+    act_messages = [m for m in logger.logged_messages if m.state == "act"]
+    assert len(act_messages) >= 2
+    for m in act_messages:
+        assert m.rf == 145.5
+        assert m.channel == 3
+        assert m.matched_ctcss == 100.0
+
+    mock_get_ctcss.assert_called_with(0)

--- a/apps/tests/test_receiver.py
+++ b/apps/tests/test_receiver.py
@@ -732,7 +732,7 @@ async def test_ctcss_mismatch_suppression(tmp_path):
             self.frequencies = []
             self.channels = []
             self._channels = []
-            self.channel_log_params = None
+            self.activity_params = None
             self.channel_spacing = channel_spacing
             self.hang_time = 1.0
             self.max_recording = 0.0

--- a/doc/json-server_example.md
+++ b/doc/json-server_example.md
@@ -11,7 +11,7 @@ For this example, Home Assistant needs to be running on the same network as Ham2
 
 These are the specific command line parameters required/recommended for this to function.  These are in addition to any others required for your situation.
 ```
---log_type json-server --log_target "<Home Assistant url> --log_active_timeout 0"
+--activity-type json-server --activity-dest "<Home Assistant url>" --activity-interval 0
 ```
 The Home Assistant (HA) url can be copy/pasted from Home Assistant|Settings|Automation & scenes|<your automation>|Webhook Trigger.  Altough HA shows only the Webhook ID the copy includes the url (with the ID).
 
@@ -50,4 +50,4 @@ mode: single
 ## Important notes
 Ham2mon can generate a lot of messages which could result in a significant amount of network traffic and overhead on Home Assistant.  Although the example automation has some throttling (triggers no more than once every 30 seconds) all the messages are still received by HA.
 
-Additional ham2mon options can improve this.  For example, recording voice only and locking out channels/ranges that are not of interest.  Also, disable activity logging to send only on/off events (`--log_active_timeout 0`)
+Additional ham2mon options can improve this.  For example, recording voice only and locking out channels/ranges that are not of interest.  Also, disable activity logging to send only on/off events (`--activity-interval 0`)


### PR DESCRIPTION
# Refactor logging: isolate standard loggers and merge channel debug activity

This commit focuses on standardizing the terminology for channel state tracking (moving from "channel logging" to "activity logging") and clean isolation of standard logging behavior.

## Summary of Changes

### 1. Architectural & Renaming Refactor (Activity Logging)
To prevent confusion between standard Python text logging and the tracking/exporting of channel state events (like transmissions), the entire channel event logging system was refactored:
* **`ChannelLogger`** is renamed to **`ActivityLogger`** in `apps/channel_loggers.py`.
* **`ChannelLogParams`** is renamed to **`ActivityParams`**.
* The command-line option parameters and internal variables are renamed to use `activity` nomenclature instead of `channel_log`:
  * `target` $\rightarrow$ `dest` (destination file or server endpoint)
  * `timeout` $\rightarrow$ `interval` (heartbeat interval for active channels)
* All importing files (`ham2mon.py`, `receiver.py`, `scanner.py`, `classification.py`, `center_frequency_provider.py`, `cursesgui.py`, `BaseTuner.py`, `frequency_manager.py`) have been updated to use the new `ActivityLogger` interface and variables.

### 2. CLI Argument Modifications (Breaking)
The CLI parser (`h2m_parser.py`) long options were changed to use standard hyphenation:
* `--log_type` $\rightarrow$ **`--activity-type`** (dest: `activity_type`)
* `--log_target` $\rightarrow$ **`--activity-dest`** (dest: `activity_dest`)
* `--log_active_timeout` $\rightarrow$ **`--activity-interval`** (dest: `activity_interval`)

### 3. Isolation of Standard Loggers & Debug Merging
* **Removal of the `Debug` Logger Class**: The `Debug(ChannelLogger)` class has been removed from `channel_loggers.py`. Previously, it manually intercepted messages to output them via standard `logging.debug(msg)`.
* **Consolidation**: Debug logs for channel state changes are now handled cleanly by standard module-level loggers (`logger = logging.getLogger(f"ham2mon.{__name__}")`) instead of a dedicated UI-driven logger class. 
* **urllib3 Silence**: The suppression configuration for `urllib3`'s verbose logs was moved from the `JsonToServer` constructor inside `channel_loggers.py` to global application startup in `ham2mon.py`.

### 4. Test Suite Enhancements (`test_channel_loggers.py`)
* The test file `apps/tests/test_channel_loggers.py` added the following tests:
  * Factory generation using `ActivityLogger.get_logger()` with `ActivityParams`.
  * The behavior of `FixedField`, `JsonToServer`, and `NoOp` loggers under the new parameter naming scheme.