### PR TITLE
Refactor spectrum mapping

### DIFF
--- a/apps/cursesgui.py
+++ b/apps/cursesgui.py
@@ -12,6 +12,7 @@ import numpy as np
 import logging
 from pathlib import PurePath
 from frequency_manager import ConfigFrequency, ChannelFrequency, ChannelList, FrequencyList
+from utilities import baseband_to_bin, build_column_edges, index_to_column
 
 logger = logging.getLogger(f"ham2mon.{__name__}")
 
@@ -135,11 +136,23 @@ class SpectrumWindow(object):
             self.min_db = self.max_db - 10
 
         # Split the data into N window bins
-        # N is window width of the inner window
-        win_bins = np.array_split(data, self.dims[1]-self.chars)
+        # N is window width of the inner window.
+        # col_edges[col] is the first data index belonging to column `col`;
+        # col_edges[num_cols] is a trailing sentinel equal to L.  This is the
+        # single source of truth for the data-index <-> column mapping and is
+        # reused below to place channel markers, so the two can never drift
+        # apart the way separately-derived formulas could.
+        num_cols = self.dims[1] - self.chars
+        L = len(data)
+        col_edges = build_column_edges(L, num_cols)
         win_bin_max = []
-        for win_bin in win_bins:
-            win_bin_max.append(np.max(win_bin))
+        for col in range(num_cols):
+            start_idx = col_edges[col]
+            end_idx = col_edges[col + 1]
+            if start_idx < end_idx:
+                win_bin_max.append(np.max(data[start_idx:end_idx]))
+            else:
+                win_bin_max.append(data[min(start_idx, L - 1)])
 
         # Convert to dB
         win_bin_max_db = 10*np.log10(win_bin_max)
@@ -206,6 +219,7 @@ class SpectrumWindow(object):
         string = ">" + "%+03d" % self.threshold_db
         self.win.addnstr(pos_yt, (self.dims[1] - self.chars), string,
                          self.chars, curses.color_pair(2))
+
         # Hide cursor
         self.win.leaveok(1)
 

--- a/apps/scanner.py
+++ b/apps/scanner.py
@@ -19,7 +19,7 @@ from channel_loggers import ActivityParams, ChannelMessage, ActivityLogger
 from classification import ClassifierParams
 from center_frequency_provider import FrequencyGroup, FrequencyProvider
 from frequency_manager import FrequencyManager, FrequencyList, FrequencyConfiguration, ChannelFrequency, ChannelList
-from utilities import baseband_to_frequency, frequency_to_baseband
+from utilities import baseband_to_frequency, frequency_to_baseband, baseband_to_bin, bin_to_baseband
 from dataclasses import dataclass, field
 
 logger = logging.getLogger(f"ham2mon.{__name__}")
@@ -225,8 +225,7 @@ class Scanner(object):
             estimate.channel_estimate(self.spectrum, threshold))
 
         # Convert channels from bin indices to baseband frequency in Hz
-        channels = (channels-len(self.spectrum)/2) *\
-            self.samp_rate/len(self.spectrum)
+        channels = bin_to_baseband(channels, self.samp_rate, len(self.spectrum))
 
         # Round channels to channel spacing
         # Note this affects tuning the demodulators
@@ -247,8 +246,7 @@ class Scanner(object):
         if self.spectrum is None or len(self.spectrum) == 0:
             return -100.0
 
-        bin_idx = int(np.round((bb * len(self.spectrum) / self.samp_rate) + len(self.spectrum) / 2))
-        bin_idx = max(0, min(len(self.spectrum) - 1, bin_idx))
+        bin_idx = baseband_to_bin(bb, self.samp_rate, len(self.spectrum))
 
         power = self.spectrum[bin_idx]
         if power <= 0:

--- a/apps/tests/test_utilities.py
+++ b/apps/tests/test_utilities.py
@@ -1,0 +1,39 @@
+import numpy as np
+from utilities import baseband_to_bin, bin_to_baseband, build_column_edges, index_to_column
+
+def test_baseband_to_bin_center_and_edges() -> None:
+    # center of spectrum is bb=0
+    assert baseband_to_bin(0.0, samp_rate=2_000_000.0, spectrum_len=2048) == 1024
+    # left/right edges clip into range rather than overflow
+    assert baseband_to_bin(-2_000_000.0, samp_rate=2_000_000.0, spectrum_len=2048) == 0
+    assert baseband_to_bin(2_000_000.0, samp_rate=2_000_000.0, spectrum_len=2048) == 2047
+
+def test_baseband_bin_roundtrip() -> None:
+    samp_rate: float = 2_000_000.0
+    L: int = 2048
+    for idx in [0, 1, 512, 1024, 1500, 2047]:
+        bb: float = bin_to_baseband(float(idx), samp_rate, L)
+        assert abs(baseband_to_bin(bb, samp_rate, L) - idx) <= 1  # rounding tolerance
+
+def test_bin_to_baseband_vectorized() -> None:
+    # channel_estimate() returns a numpy array of fractional bin indices;
+    # bin_to_baseband must handle that without a per-element Python loop
+    idx: np.ndarray = np.array([0.0, 1024.0, 2047.0])
+    bb: np.ndarray = bin_to_baseband(idx, samp_rate=2_000_000.0, spectrum_len=2048)
+    assert isinstance(bb, np.ndarray)
+    assert np.allclose(bb, [-1_000_000.0, 0.0, 999_023.4375])
+
+def test_build_column_edges_covers_all_indices_no_overlap() -> None:
+    for L, num_cols in [(2048, 120), (100, 77), (50, 80)]:  # last case: num_cols > L
+        edges: list[int] = build_column_edges(L, num_cols)
+        assert edges[0] == 0 and edges[-1] == L
+        assert all(edges[i] <= edges[i + 1] for i in range(len(edges) - 1))
+
+def test_index_to_column_matches_bar_column() -> None:
+    # regression test for the marker/bar alignment guarantee
+    L: int = 2048
+    num_cols: int = 120
+    edges: list[int] = build_column_edges(L, num_cols)
+    for bin_idx in [0, 1, 500, 1024, 2000, 2047]:
+        col: int = index_to_column(bin_idx, edges)
+        assert edges[col] <= bin_idx < edges[col + 1] or col == num_cols - 1

--- a/apps/utilities.py
+++ b/apps/utilities.py
@@ -3,6 +3,11 @@ Created on Thu Mar 7 2024
 
 @author: john
 """
+import bisect
+from typing import overload
+import numpy as np
+from numpy.typing import NDArray
+
 def frequency_to_baseband(freq: float, center_freq: int, channel_spacing: int) -> int:
     """Returns baseband frequency in Hz
     """
@@ -14,3 +19,44 @@ def baseband_to_frequency(bb_freq: int, center_freq: int) -> float:
     """Return frequency in Mhz
     """
     return (bb_freq + center_freq)/1E6
+
+def baseband_to_bin(bb: float, samp_rate: float, spectrum_len: int) -> int:
+    """Convert a baseband offset (Hz) to an FFT bin index, clipped to valid range.
+
+    bb=0 is the center bin; -samp_rate/2 is the left edge (bin 0);
+    +samp_rate/2 is the right edge (bin spectrum_len-1).
+    """
+    if spectrum_len <= 0:
+        raise ValueError("spectrum_len must be positive")
+    bin_idx = int(round((bb * spectrum_len / samp_rate) + spectrum_len / 2))
+    return max(0, min(spectrum_len - 1, bin_idx))
+
+@overload
+def bin_to_baseband(bin_idx: float, samp_rate: float, spectrum_len: int) -> float: ...
+
+@overload
+def bin_to_baseband(bin_idx: NDArray[np.float64], samp_rate: float, spectrum_len: int) -> NDArray[np.float64]: ...
+
+def bin_to_baseband(
+    bin_idx: float | NDArray[np.float64], samp_rate: float, spectrum_len: int
+) -> float | NDArray[np.float64]:
+    """Convert an FFT bin index (or array of indices, incl. fractional) to
+    baseband offset in Hz. Inverse of baseband_to_bin (up to rounding).
+    Accepts a scalar or a numpy array, matching channel_estimate()'s output.
+    """
+    return (bin_idx - spectrum_len / 2) * samp_rate / spectrum_len
+
+def build_column_edges(length: int, num_cols: int) -> list[int]:
+    """Partition `length` items into `num_cols` near-equal-width groups.
+    Returns a list of num_cols+1 boundaries; group `col` covers
+    data[edges[col]:edges[col+1]].
+    """
+    edges = [int(col * length / num_cols) for col in range(num_cols)]
+    edges.append(length)
+    return edges
+
+def index_to_column(index: int, col_edges: list[int]) -> int:
+    """Given an index into the original data and the edges from
+    build_column_edges, return which column it falls in."""
+    col = bisect.bisect_right(col_edges, index) - 1
+    return max(0, min(len(col_edges) - 2, col))


### PR DESCRIPTION
Previously there was code duplication with converting frequencies to their baseband counterparts (and vice-versa).  This PR abstracts this out and makes it testable in an isolated way with pytest.