### PR TITLE
UI improvements

### DIFF
--- a/apps/cursesgui.py
+++ b/apps/cursesgui.py
@@ -269,8 +269,10 @@ class ChannelWindow(object):
     """
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, screen, width=None):
+    def __init__(self, screen, width=None, num_demod: int | None = None):
         self.screen = screen
+
+        self.num_demod = num_demod
 
         # Create a window object in the bottom half of the screen
         # Place on left side and to the right of the border
@@ -287,6 +289,14 @@ class ChannelWindow(object):
 
         self.entries: list[ChannelWindow.ChannelEntry] = []
 
+        # Sticky-row state: maps rf frequency (float) -> row index so that a
+        # frequency keeps the same display row for as long as it is visible
+        # (active or hanging).  Rows are reclaimed into _free_rows only when a
+        # frequency completely disappears from the channel list.
+        self._row_map: dict[float, int] = {}
+        self._rf_by_row: dict[int, float] = {}   # reverse of _row_map; O(1) row -> rf lookup
+        self._free_rows: list[int] = []
+
     class ChannelEntry(object):
         win = None
 
@@ -296,6 +306,7 @@ class ChannelWindow(object):
             self.width = width
             self.prev_channel: ChannelFrequency | None = None
             self.prev_idx: int | None = None
+            self.prev_show_placeholder: bool | None = None
 
             self.attrs = { 'bold_freq': curses.color_pair(2) | curses.A_BOLD,
                            'bold_icon': curses.color_pair(2),
@@ -305,15 +316,20 @@ class ChannelWindow(object):
         def reset_cache(self) -> None:
             self.prev_channel = None
             self.prev_idx = None
+            self.prev_show_placeholder = None
 
-        def set(self, channel: ChannelFrequency, idx: int = 0) -> None:
-            if self.prev_channel != channel or self.prev_idx != idx:
+        def set(self, channel: ChannelFrequency, idx: int = 0,
+                show_placeholder: bool = True) -> None:
+            if (self.prev_channel != channel or self.prev_idx != idx
+                    or self.prev_show_placeholder != show_placeholder):
                 self.channel = channel
                 self.idx = idx
+                self.show_placeholder = show_placeholder
                 self.draw()
 
             self.prev_channel = channel
             self.prev_idx = idx
+            self.prev_show_placeholder = show_placeholder
 
         def draw(self) -> None:
             row = self.row
@@ -324,9 +340,19 @@ class ChannelWindow(object):
             if win is None:
                 return
 
+            # Clear the entire row width to prevent stale characters from previous draws (e.g. uncleared dots)
+            win.addnstr(row, col, ' ' * self.width, self.width)
+
             if channel is None:
-                text = ' ' * self.width
-                win.addnstr(row, col, text, self.width)
+                if not self.show_placeholder:
+                    return
+                idx_str = f'{self.idx:>2d}:'
+                scanning_str = ' Scanning...'
+                win.addnstr(row, col, idx_str, len(idx_str),
+                            curses.color_pair(7) | curses.A_DIM)
+                win.addnstr(row, col + len(idx_str), scanning_str,
+                            max(0, self.width - len(idx_str)),
+                            curses.color_pair(6) | curses.A_DIM)
                 return
 
             idx_str = f'{self.idx:02d}:'
@@ -401,28 +427,81 @@ class ChannelWindow(object):
             # Reset caches after a geometry-driven rebuild to force a full redraw
             for entry in self.entries:
                 entry.reset_cache()
+            # Geometry changed: discard all sticky-row assignments so they are
+            # rebuilt cleanly against the new entry count.
+            self._row_map.clear()
+            self._rf_by_row.clear()
+            self._free_rows = list(range(usable_height))
 
     def draw_channels(self, channels: list[ChannelFrequency]):
-        """Draws tuned channels list
+        """Draws tuned channels list using sticky row anchoring.
 
-        Args:
-            rf_channels [string]: List of strings in MHz
+        Each RF frequency is assigned a row index the first time it becomes
+        visible (active or hanging) and keeps that row until it completely
+        disappears from the channel list.  Rows are reclaimed into a free pool
+        in ascending order so newly arriving frequencies take the lowest
+        available slot, giving a natural top-to-bottom fill pattern.
+
+        The label shown next to each frequency is its row index, which is
+        permanent for as long as the frequency is visible.  The keyboard
+        lockout hotkeys (``0``–``9``) correspond to these row indices.
+        ham2mon uses get_rf_by_row() to translate the pressed digit into an
+        RF frequency which is passed directly to Scanner.add_lockout().
         """
-        # Draw the tuned channels prefixed by index in list (demodulator index)
-        # Use color if tuned channel is active during this scan_cycle
-        subset = [c for c in channels if c.active or c.hanging]  # needs to match Scanner.add_lockout
+        subset = [c for c in channels if c.active or c.hanging]
+        visible_rfs = {c.rf for c in subset}
 
-        for idx, entry in enumerate(self.entries):
-            if idx >= len(subset):
-                entry.set(None)
-            else:
-                entry.set(subset[idx], idx)
+        # Initialise _free_rows on the very first call (before any geometry
+        # change has fired draw_frame with a mismatched entry count).
+        if not self._row_map and not self._free_rows and self.entries:
+            self._free_rows = list(range(len(self.entries)))
+
+        # Release rows belonging to frequencies that are no longer visible.
+        released = [row for rf, row in self._row_map.items() if rf not in visible_rfs]
+        for rf in [rf for rf in list(self._row_map) if rf not in visible_rfs]:
+            row = self._row_map.pop(rf)
+            self._rf_by_row.pop(row, None)
+        # Keep free list sorted ascending so the lowest slot is always taken
+        # first, preserving a tidy top-to-bottom fill order.
+        self._free_rows = sorted(self._free_rows + released)
+
+        # Assign a row to any newly visible frequency.
+        for channel in subset:
+            if channel.rf not in self._row_map and self._free_rows:
+                row = self._free_rows.pop(0)
+                self._row_map[channel.rf] = row
+                self._rf_by_row[row] = channel.rf
+
+        # Build a row-indexed view: row -> channel.
+        row_content: dict[int, ChannelFrequency] = {}
+        for channel in subset:
+            row = self._row_map.get(channel.rf)
+            if row is not None:
+                row_content[row] = channel
+
+        # Render every entry: draw the assigned channel at its stable row index,
+        # passing the row number as the display index (lockout hotkey label).
+        # row_idx is always passed, even for idle rows, so the "Scanning..."
+        # placeholder in ChannelEntry.draw() can display the correct row
+        # number for empty slots too.
+        for row_idx, entry in enumerate(self.entries):
+            is_demod_slot = self.num_demod is None or row_idx < self.num_demod
+            entry.set(row_content.get(row_idx), row_idx,
+                      show_placeholder=is_demod_slot)
 
         # Hide cursor
         self.win.leaveok(1)
 
         # Update virtual window
         self.win.noutrefresh()
+
+    def get_rf_by_row(self, row: int) -> float | None:
+        """Return the RF frequency currently anchored to *row*, or None.
+
+        Used by the lockout key handler in ham2mon to translate a pressed
+        digit (row number) into an RF frequency for Scanner.add_lockout().
+        """
+        return self._rf_by_row.get(row)
 
     def cleanup(self) -> None:
         if hasattr(self, 'win') and self.win:
@@ -1104,7 +1183,7 @@ class RxWindow(object):
 
 
 def create_bottom_row_windows(screen, chan_min_width=20, lock_min_width=20,
-                               weights=None):
+                              weights=None, num_demod: int | None = None):
     """Creates and positions the Channel, Lockout, and Receiver windows.
 
     Channel and Lockout display open-ended, user-supplied label text, so
@@ -1121,6 +1200,8 @@ def create_bottom_row_windows(screen, chan_min_width=20, lock_min_width=20,
         weights (dict): optional override of {'chan', 'lock', 'rx'} growth
             weights; defaults to Channel/Lockout growing twice as fast as
             Receiver once minimums are satisfied
+        num_demod (int): optional count of available demodulators to cap
+            scanning placeholder rendering
 
     Returns:
         tuple: (ChannelWindow, LockoutWindow, RxWindow) instances
@@ -1140,7 +1221,7 @@ def create_bottom_row_windows(screen, chan_min_width=20, lock_min_width=20,
     min_widths = {'chan': chan_min_width, 'lock': lock_min_width, 'rx': rx_min_width}
     widths = compute_panel_widths(total_usable_width, min_widths, weights)
 
-    chanwin = ChannelWindow(screen, width=widths['chan'])
+    chanwin = ChannelWindow(screen, width=widths['chan'], num_demod=num_demod)
     lockoutwin = LockoutWindow(screen, width=widths['lock'], x_offset=widths['chan'] + 1)
     rxwin = RxWindow(screen, width=widths['rx'])
     return chanwin, lockoutwin, rxwin

--- a/apps/cursesgui.py
+++ b/apps/cursesgui.py
@@ -11,6 +11,7 @@ import time
 import numpy as np
 import logging
 from pathlib import PurePath
+import bisect
 from frequency_manager import ConfigFrequency, ChannelFrequency, ChannelList, FrequencyList
 from utilities import baseband_to_bin, build_column_edges, index_to_column
 
@@ -91,6 +92,7 @@ class SpectrumWindow(object):
         self.max_db = 50
         self.min_db = -20
         self.threshold_db = 20
+        self.samp_rate = 0
 
         # Create a window object in top half of the screen, within the border
         screen_dims = screen.getmaxyx()
@@ -117,11 +119,15 @@ class SpectrumWindow(object):
             except Exception:
                 pass
 
-    def draw_spectrum(self, data):
+    def draw_spectrum(self, data, channels=None, row_map=None):
         """Scales input spectral data to window dimensions and draws bar graph
 
         Args:
             data (numpy.ndarray): FFT power spectrum data in linear, not dB
+            channels (list[ChannelFrequency] | None): Full channel list from
+                the scanner.  When provided a self.samp_rate, lockout index
+                label is drawn at the column matching each tuned (active or hanging)
+                channel's baseband frequency.
 
         Test cases for data with min_db=-100 and max_db=0 on 80x24 terminal:
             1.0E-10 draws nothing since it is not above -100 dB
@@ -220,6 +226,66 @@ class SpectrumWindow(object):
         self.win.addnstr(pos_yt, (self.dims[1] - self.chars), string,
                          self.chars, curses.color_pair(2))
 
+        # Place a channel marker above the signal peak at its baseband frequency column.
+        if channels is not None and self.samp_rate > 0:
+            subset = [c for c in channels if c.active or c.hanging]
+            occupied_rows = {}  # Tracks occupied columns per row: {row_y: set(col_indices)}
+
+            def is_free(y: int, c: int, length: int) -> bool:
+                occupied = occupied_rows.get(y, set())
+                return all(idx not in occupied for idx in range(c, c + length))
+
+            for display_idx, channel in enumerate(subset):
+                # bb=0 is centre; -samp_rate/2 is left edge; +samp_rate/2 is right.
+                # Look up the column using col_edges -- the exact same
+                # partition the bars above were built from -- rather than
+                # re-deriving the index->column mapping with a second
+                # formula, so markers can never disagree with the bars.
+                bin_idx = baseband_to_bin(channel.bb, self.samp_rate, L)
+                col = index_to_column(bin_idx, col_edges)
+                if row_map is not None and channel.rf in row_map:
+                    label = str(row_map[channel.rf])
+                else:
+                    label = str(display_idx)
+                # Clamp column so the label fits within the usable columns.
+                col = max(0, min(num_cols - len(label), col))
+
+                # Retrieve the top of the signal at this column
+                signal_top = pos_y[col]
+                target_y = max(0, signal_top - 2)
+
+                # Find the nearest free row (staggering upwards first, then downwards)
+                marker_y = target_y
+                found = False
+                for y in range(target_y, -1, -1):
+                    if is_free(y, col, len(label)):
+                        marker_y = y
+                        found = True
+                        break
+
+                if not found:
+                    for y in range(target_y + 1, self.dims[0]):
+                        if is_free(y, col, len(label)):
+                            marker_y = y
+                            found = True
+                            break
+
+                # If every row is occupied at this column, marker_y stays at
+                # target_y and overwrites whatever is there — acceptable graceful
+                # degradation for extremely congested displays.
+
+                # Record the occupied columns for this row
+                if marker_y not in occupied_rows:
+                    occupied_rows[marker_y] = set()
+                for idx in range(col, col + len(label)):
+                    occupied_rows[marker_y].add(idx)
+
+                attr = (curses.color_pair(7)
+                        if channel.active else curses.color_pair(7) | curses.A_DIM)
+                try:
+                    self.win.addnstr(marker_y, col, label, len(label), attr)
+                except curses.error:
+                    pass
         # Hide cursor
         self.win.leaveok(1)
 
@@ -310,8 +376,8 @@ class ChannelWindow(object):
 
             self.attrs = { 'bold_freq': curses.color_pair(2) | curses.A_BOLD,
                            'bold_icon': curses.color_pair(2),
-                           'normal_freq': curses.color_pair(6),
-                           'normal_icon': curses.color_pair(6) }
+                           'normal_freq': curses.color_pair(2) | curses.A_DIM,
+                           'normal_icon': curses.color_pair(2) | curses.A_DIM }
 
         def reset_cache(self) -> None:
             self.prev_channel = None
@@ -355,7 +421,7 @@ class ChannelWindow(object):
                             curses.color_pair(6) | curses.A_DIM)
                 return
 
-            idx_str = f'{self.idx:02d}:'
+            idx_str = f'{self.idx:>2d}:'
             freq_str = f'{channel.rf:>9.4f}'
             if freq_str.endswith('0'):
                 freq_str = freq_str[:-1] + ' '
@@ -365,7 +431,9 @@ class ChannelWindow(object):
             attributes = (self.attrs['bold_freq'], self.attrs['bold_icon']) if channel.active else (
                 self.attrs['normal_freq'], self.attrs['normal_icon'])
 
-            win.addnstr(row, col, idx_str, len(idx_str), attributes[0])
+            idx_attr = (curses.color_pair(7)
+                        if channel.active else curses.color_pair(7) | curses.A_DIM)
+            win.addnstr(row, col, idx_str, len(idx_str), idx_attr)
             win.addnstr(row, col + 3, freq_str, len(freq_str), attributes[0])
             win.addnstr(row, col + 12, icon, 1, attributes[1])
 
@@ -502,6 +570,15 @@ class ChannelWindow(object):
         digit (row number) into an RF frequency for Scanner.add_lockout().
         """
         return self._rf_by_row.get(row)
+
+    def get_row_map(self) -> dict[float, int]:
+        """Return a snapshot of the current RF-frequency → row-index mapping.
+
+        The returned dict is a shallow copy so callers cannot inadvertently
+        mutate internal state.  Used by SpectrumWindow to draw channel index
+        markers that match the Channel panel row labels and lockout hotkeys.
+        """
+        return dict(self._row_map)
 
     def cleanup(self) -> None:
         if hasattr(self, 'win') and self.win:

--- a/apps/ham2mon.py
+++ b/apps/ham2mon.py
@@ -91,7 +91,11 @@ class MyDisplay():
 
         # Create windows
         self.specwin = cursesgui.SpectrumWindow(self.stdscr)
-        self.chanwin, self.lockoutwin, self.rxwin = cursesgui.create_bottom_row_windows(self.stdscr)
+        num_demod = None
+        if self.scanner and hasattr(self.scanner, 'receiver') and hasattr(self.scanner.receiver, 'demodulators'):
+            num_demod = len(self.scanner.receiver.demodulators)
+        self.chanwin, self.lockoutwin, self.rxwin = cursesgui.create_bottom_row_windows(
+            self.stdscr, num_demod=num_demod)
 
         # Get the initial settings for GUI
         self.rxwin.gains = self.scanner.filter_and_set_gains(PARSER.gains)
@@ -222,9 +226,13 @@ class MyDisplay():
 
         # Send keystroke to lockout window and update lockout channels if True
         if self.lockoutwin.proc_keyb_set_lockout(keyb) and self.rxwin.freq_entry == 'None':
-            # Subtract 48 from ascii keyb value to obtain 0 - 9
-            idx = keyb - 48
-            await self.scanner.add_lockout(idx)
+            # Translate pressed digit to the stable row number, then look up
+            # the RF frequency anchored to that row.  get_rf_by_row() returns
+            # None when no channel occupies the row, in which case we skip.
+            row = keyb - 48
+            rf = self.chanwin.get_rf_by_row(row)
+            if rf is not None:
+                await self.scanner.add_lockout(rf)
         if self.lockoutwin.proc_keyb_clear_lockout(keyb):
             await self.scanner.clear_lockout()
 

--- a/apps/ham2mon.py
+++ b/apps/ham2mon.py
@@ -103,6 +103,7 @@ class MyDisplay():
         self.rxwin.step = self.scanner.step
         self.rxwin.steps = self.scanner.steps
         self.rxwin.samp_rate = self.scanner.samp_rate
+        self.specwin.samp_rate = self.scanner.samp_rate
         self.rxwin.squelch_db = self.scanner.squelch_db
         self.rxwin.volume_db = self.scanner.volume_db
         self.rxwin.record = self.scanner.record
@@ -142,8 +143,8 @@ class MyDisplay():
             return
 
         # Update the spectrum, channel, and rx displays
-        self.specwin.draw_spectrum(self.scanner.spectrum)
         self.chanwin.draw_channels(self.scanner.channels)
+        self.specwin.draw_spectrum(self.scanner.spectrum, self.scanner.channels, self.chanwin.get_row_map())
         self.lockoutwin.draw_channels(self.scanner.frequencies, self.scanner.channels)
         self.rxwin.draw_rx()
 

--- a/apps/scanner.py
+++ b/apps/scanner.py
@@ -376,14 +376,15 @@ class Scanner(object):
 
         return sweep
 
-    async def add_lockout(self, idx: int) -> None:
-        # need the same subset here as in cursesgui.ChannelWindow so idx gets the right channel
-        subset = [c for c in self.channels if c.active or c.hanging]
-        try:
-            self.frequencies = await self.frequency_manager.change({'single': subset[idx].rf, 'locked': True, 'mode': 'add'})
-        except IndexError:
-            # user selected a digit but no channels in interface
-            return
+    async def add_lockout(self, rf: float) -> None:
+        """Lock out the given RF frequency.
+
+        The RF value is supplied directly by the UI layer (translated from a
+        pressed digit via ChannelWindow.get_rf_by_row) so no subset indexing
+        is required here.
+        """
+        self.frequencies = await self.frequency_manager.change(
+            {'single': rf, 'locked': True, 'mode': 'add'})
 
     async def clear_lockout(self) -> None:
         """


### PR DESCRIPTION
### Title

`ui: Add demodulator markers to SpectrumWindow and sticky row locking to ChannelWindow`

### Description
This PR introduces two UI enhancements to improve usability and visualization of active demodulators in the curses-based user interface:

1. **SpectrumWindow Demodulator Markers**: Draws visual index markers directly onto the spectrum display to show the current frequency positions of active demodulators.
2. **ChannelWindow Sticky Row**: Introduces a sticky row option in the channel list that locks focus to a specific demodulator index, ensuring it remains visible and tracked as channel list contents update dynamically.

#### **Commits included:**
* `ChannelWindow: sticky row locked to demodulator index`
* `SpectrumWindow: draw demodulator index markers on spectrum`